### PR TITLE
Remove Python 3.7 compatibility code and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The code herein has been in use in production here and there on the internet sin
 
 ## Requirements
 
-ABNF is tested with Python 3.8-12. The package requires typing_extensions >=4, and for python 3.7, importlib_metadata.
+ABNF is tested with Python 3.8-12.
 
 
 ## Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,11 @@ classifiers =
     Topic :: Software Development :: Interpreters
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 platforms = any
 
 [options]
@@ -26,10 +27,7 @@ package_dir=
     = src
 packages=find:
 
-install_requires=
-    typing_extensions >=4, <5
-    importlib_metadata; python_version < '3.8'
-python_requires = >=3
+python_requires = >=3.8
 zip_safe = False
 bdist_wheel = universal:1
 [options.packages.find]

--- a/src/abnf/__init__.py
+++ b/src/abnf/__init__.py
@@ -2,10 +2,7 @@
 
 import sys
 
-if sys.version_info >= (3, 8):
-    from importlib.metadata import PackageNotFoundError, metadata  # pragma: no cover
-else:
-    from importlib_metadata import metadata, PackageNotFoundError  # pragma: no cover
+from importlib.metadata import PackageNotFoundError, metadata  # pragma: no cover
 
 from abnf.parser import GrammarError, LiteralNode, Node, NodeVisitor, ParseError, Rule
 

--- a/src/abnf/typing.py
+++ b/src/abnf/typing.py
@@ -6,9 +6,6 @@ The code branches on version instead of using try-except so that mypy is happy.
 
 import sys  # pragma: no cover
 
-if sys.version_info >= (3, 8):  # pragma: no cover
-    from typing import Protocol, runtime_checkable
-else:
-    from typing_extensions import Protocol, runtime_checkable  # pragma: no cover
+from typing import Protocol, runtime_checkable
 
 __all__ = ["Protocol", "runtime_checkable"]  # pragma: no cover


### PR DESCRIPTION
With removal of support for Python 3.7 the compatibility code can be dropped and the dependencies that were only needed on Python 3.7 can be removed.

I have also updated the supported Python versions in setup.cfg.