### PR TITLE
Fix-lowercase

### DIFF
--- a/src/abnf/grammars/rfc7489.py
+++ b/src/abnf/grammars/rfc7489.py
@@ -32,8 +32,8 @@ class Rule(_Rule):
             'URI = %x6D %x61 %x69 %x6C %x74 %x6F %x3A addr-spec',
             'dmarc-uri = URI [ "!" 1*DIGIT [ "k" / "m" / "g" / "t" ] ]',
             
-            'dmarc-version = "v" *WSP "=" *WSP %x44 %x4d %x41 %x52 %x43 %x31',
-            'dmarc-sep = *WSP %x3b *WSP',
+            'dmarc-version = "v" *WSP "=" *WSP %x44 %x4D %x41 %x52 %x43 %x31',
+            'dmarc-sep = *WSP %x3B *WSP',
             'dmarc-request = "p" *WSP "=" *WSP ( "none" / "quarantine" / "reject" )',
             'dmarc-srequest  = "sp" *WSP "=" *WSP ( "none" / "quarantine" / "reject" )',
             'dmarc-auri = "rua" *WSP "=" *WSP dmarc-uri *(*WSP "," *WSP dmarc-uri)',

--- a/src/abnf/grammars/rfc9051.py
+++ b/src/abnf/grammars/rfc9051.py
@@ -74,7 +74,7 @@ class Rule(_Rule):
         'capability = ("AUTH=" auth-type) / atom',
         'capability-data = "CAPABILITY" *(SP capability) SP "IMAP4rev2" '
         "*(SP capability)",
-        "CHAR8 = %x01-ff",
+        "CHAR8 = %x01-FF",
         "charset = atom / quoted",
         'childinfo-extended-item = "CHILDINFO" SP "(" '
         "list-select-base-opt-quoted *(SP list-select-base-opt-quoted) "


### PR DESCRIPTION
I'm writing (yet another) parser generator and used your excellent resources to test my ABNF parser.

I believe I found some small bugs in these grammars, since the standard doesn't allow for lowercase hex digits in hex-val.