### PR TITLE
Dependabot: ignore pyo3 minor/major bumps.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,11 @@ updates:
       interval: weekly
       time: "04:00"
       timezone: America/Kentucky/Monticello
+    ignore:
+      # pyo3 makes breaking API changes on every minor (0.x.y).
+      # Treat each pyo3 bump as a deliberate migration task; do not
+      # auto-propose semver-minor or semver-major updates.
+      - dependency-name: "pyo3"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"


### PR DESCRIPTION
pyo3 breaks API on every minor release in 0.x — going from 0.22 to 0.23 (or further) is a deliberate migration task, not a drop-in update.  Dependabot has just opened a PR bumping pyo3 from 0.22.6 to 0.28.3 that fails to compile (two `into_py(py)` call sites no longer exist in the modern API, plus several deprecation warnings).  Allowing patch updates within 0.22.x is fine and useful; the others should stay out of the inbox.

When the time comes to migrate, do it as a dedicated branch: update Cargo.toml, replace `into_py` with the current API (typically `into_pyobject` or `into_bound_py_any`), rename `downcast`/`downcast_into` to `cast`/`cast_into`, address the `#[pyclass]` FromPyObject opt-in, and run the full Rust + Python suite under both backends.