### PR TITLE
Security hardening (Phases 4-5): SBOM, attestations, dependabot cooldown, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for abnf.
+#
+# Documents ownership and routes review requests to the maintainer.
+# The default-branch ruleset does not currently *require* code-owner
+# review (require_code_owner_review is off, appropriate for a solo
+# project), so this file is advisory: it auto-requests @declaresub on
+# pull requests rather than blocking merges.
+* @declaresub

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: daily
       time: "04:00"
       timezone: America/Kentucky/Monticello
+    # Wait 7 days after a release before proposing it. Dodges the
+    # window in which a freshly-published malicious version is live
+    # but not yet caught/yanked.
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -14,6 +19,8 @@ updates:
       interval: weekly
       time: "04:00"
       timezone: America/Kentucky/Monticello
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: cargo
     # Rust workspace for the optional `abnf-rust` companion package.
@@ -22,6 +29,8 @@ updates:
       interval: weekly
       time: "04:00"
       timezone: America/Kentucky/Monticello
+    cooldown:
+      default-days: 7
     ignore:
       # pyo3 makes breaking API changes on every minor (0.x.y).
       # Treat each pyo3 bump as a deliberate migration task; do not

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,38 @@ jobs:
       # setuptools-scm picks the version up from the tag itself.
       run: python3 -m build
 
+    - name: Generate CycloneDX SBOM
+      # Describes the runtime dependency closure a user actually
+      # installs (`pip install abnf[rust]`), read from the committed
+      # uv.lock — NOT the dev toolchain.  Written to sbom/ rather than
+      # dist/ so it is never swept into the PyPI upload (a stray file
+      # in dist/ would be published to the index and can break the
+      # publish).  It is attached to the GitHub release at the end.
+      # uv and cyclonedx-bom are version-pinned for reproducibility.
+      run: |
+        python3 -m pip install --user 'uv==0.11.8'
+        export PATH="$HOME/.local/bin:$PATH"
+        mkdir -p sbom
+        uv export --no-dev --extra rust --no-hashes --no-emit-project \
+          --format requirements-txt -o sbom/requirements.txt
+        uvx --from 'cyclonedx-bom==7.3.0' cyclonedx-py requirements \
+          sbom/requirements.txt --output-format JSON > sbom/abnf.cdx.json
+
     - name: Upload abnf dists
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: abnf-dists
         path: dist/
+
+    - name: Upload SBOM
+      # Separate artifact (not abnf-dists) so the publish jobs, which
+      # download only abnf-dists / abnf-rust-*, never see it.  Only the
+      # final github-release job (which downloads every artifact) picks
+      # it up and attaches it to the release.
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: abnf-sbom
+        path: sbom/abnf.cdx.json
 
   build-abnf-rust-sdist:
     name: Build abnf-rust sdist
@@ -225,6 +252,10 @@ jobs:
         # and we need to retry without yanking what already
         # published.
         skip-existing: true
+        # Generate & upload PEP 740 attestations (default, made
+        # explicit so a future action default change can't silently
+        # drop release provenance).
+        attestations: true
 
   publish-abnf-pypi:
     name: Publish abnf to PyPI
@@ -254,6 +285,7 @@ jobs:
         # the project level, so this is purely a "skip what already
         # uploaded" hatch — version pinning still drives behaviour.
         skip-existing: true
+        attestations: true
 
   # ----------------------------------------------------------------
   # Publish abnf-rust
@@ -287,6 +319,7 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
+        attestations: true
 
   publish-abnf-rust-pypi:
     name: Publish abnf-rust to PyPI
@@ -314,6 +347,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
       with:
         skip-existing: true
+        attestations: true
 
   # ----------------------------------------------------------------
   # Final fan-in: Sigstore-sign everything and create the release


### PR DESCRIPTION
Phases 4 & 5 of a security hardening pass. Phases 1 (rulesets) and 2 (repo settings) were applied directly via the GitHub API; this PR carries the in-repo file changes.

## Changes

**Phase 5 — Release provenance (`release.yml`)**
- **CycloneDX SBOM**: the `build-abnf` job now generates an SBOM of the runtime dependency closure (`abnf[rust]`, read from the committed `uv.lock` — not the dev toolchain). Written to `sbom/`, **never `dist/`**, so it can't be swept into the PyPI upload. Uploaded as a separate `abnf-sbom` artifact; the publish jobs (which download only `abnf-dists` / `abnf-rust-*`) never see it. The final `github-release` job downloads every artifact and attaches `abnf.cdx.json` to the GitHub release. `uv` and `cyclonedx-bom` are version-pinned.
- **Attestations**: `attestations: true` made explicit on all four `gh-action-pypi-publish` steps. This is already the action default; pinning it means a future default change can't silently drop PEP 740 provenance.

**Phase 4 — Dependencies (`dependabot.yml`)**
- 7-day `cooldown` on all three ecosystems (uv, github-actions, cargo) to avoid pulling a freshly-published malicious version inside its detection/yank window.

**Phase 1 follow-on (`CODEOWNERS`)**
- Advisory ownership routing to `@declaresub` (the branch ruleset does not *require* code-owner review, appropriate for a solo project).

## Verification
- All workflow + dependabot YAML parses.
- `zizmor 1.24.1 --persona auditor` on `release.yml`: **0 findings**. (Pre-existing findings elsewhere — codeql-action SHA-pin quirks — are untouched by this PR and below zizmor's failure threshold.)
- SBOM generation validated locally: produces a CycloneDX 1.6 doc with the runtime closure (`abnf-rust`).

## Out of scope / not in this PR
- Phase 1 rulesets and Phase 2 settings (already live on the repo via API).
- The 3 existing Dependabot alerts on `master` (surfaced separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
