### PR TITLE
Migrate abnf-rust bindings to pyo3 0.29 (supersedes #112)

### DIFF
--- a/packages/abnf-rust/Cargo.lock
+++ b/packages/abnf-rust/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "caseless"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,12 +47,6 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "equivalent"
@@ -96,15 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,9 +91,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
@@ -129,19 +108,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -169,37 +139,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -207,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -219,13 +184,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -238,12 +202,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "shlex"
@@ -270,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tinyvec"
@@ -303,9 +261,3 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"

--- a/packages/abnf-rust/Cargo.toml
+++ b/packages/abnf-rust/Cargo.toml
@@ -19,5 +19,5 @@ caseless = "0.2"
 lru = "0.18"
 mimalloc = { version = "0.1", default-features = false }
 once_cell = "1"
-pyo3 = "0.22"
+pyo3 = "0.29"
 smallvec = "1"

--- a/packages/abnf-rust/rust/pyo3/src/bootstrap.rs
+++ b/packages/abnf-rust/rust/pyo3/src/bootstrap.rs
@@ -41,7 +41,7 @@ pub fn bootstrap(py: Python<'_>, rule_cls: &Bound<'_, PyType>) -> PyResult<()> {
     // The base `Rule` class is `rule_cls.__mro__[1]` (since rule_cls
     // is expected to be `ABNFGrammarRule`, a direct subclass).
     let mro = rule_cls.getattr("__mro__")?;
-    let rule_base = mro.get_item(1)?.downcast_into::<PyType>()?;
+    let rule_base = mro.get_item(1)?.cast_into::<PyType>()?;
 
     for (name, named_rule) in registry.iter() {
         let definition = match named_rule.definition() {

--- a/packages/abnf-rust/rust/pyo3/src/errors.rs
+++ b/packages/abnf-rust/rust/pyo3/src/errors.rs
@@ -29,12 +29,12 @@ pub fn parse_error_to_pyerr(py: Python<'_>, err: ParseError, source: &str) -> Py
         Ok(o) => o,
         Err(e) => return e,
     };
-    PyErr::from_value_bound(exc)
+    PyErr::from_value(exc)
 }
 
 fn get_parse_error_class(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-    let module = py.import_bound("abnf.parser")?;
+    let module = py.import("abnf.parser")?;
     let cls = module.getattr("ParseError")?;
-    cls.downcast_into::<PyType>()
+    cls.cast_into::<PyType>()
         .map_err(|e| e.into())
 }

--- a/packages/abnf-rust/rust/pyo3/src/external.rs
+++ b/packages/abnf-rust/rust/pyo3/src/external.rs
@@ -36,7 +36,7 @@ impl PyCallbackParser {
 
 impl ExternalParser for PyCallbackParser {
     fn lparse(&self, source: &str, start: usize) -> ParseResult {
-        Python::with_gil(|py| -> ParseResult {
+        Python::attach(|py| -> ParseResult {
             // The Rust core hands us a byte offset; the Python parser
             // expects a code-point offset.  The translation is also
             // inverted on the way back in `py_match_to_rust`.
@@ -46,7 +46,7 @@ impl ExternalParser for PyCallbackParser {
                 Ok(r) => r,
                 Err(e) => return Err(handle_pyerr(py, e, &self.description, start)),
             };
-            let iter = match result.iter() {
+            let iter = match result.try_iter() {
                 Ok(it) => it,
                 Err(e) => return Err(handle_pyerr(py, e, &self.description, start)),
             };
@@ -97,7 +97,7 @@ fn handle_pyerr(
 /// as non-`ParseError` so it propagates rather than silently
 /// converting into a backtrackable failure.
 fn is_parse_error(py: Python<'_>, err: &PyErr) -> bool {
-    let module = match py.import_bound("abnf.parser") {
+    let module = match py.import("abnf.parser") {
         Ok(m) => m,
         Err(_) => return false,
     };
@@ -105,9 +105,13 @@ fn is_parse_error(py: Python<'_>, err: &PyErr) -> bool {
         Ok(c) => c,
         Err(_) => return false,
     };
-    let cls = match cls.downcast_into::<PyType>() {
+    let cls = match cls.cast_into::<PyType>() {
         Ok(c) => c,
         Err(_) => return false,
     };
-    err.matches(py, &cls)
+    // `PyErr::matches` is fallible since pyo3 0.23 (the isinstance check
+    // can itself raise).  On error, conservatively treat the exception
+    // as non-`ParseError` so it propagates rather than silently becoming
+    // a backtrackable failure.
+    err.matches(py, &cls).unwrap_or(false)
 }

--- a/packages/abnf-rust/rust/pyo3/src/nodes.rs
+++ b/packages/abnf-rust/rust/pyo3/src/nodes.rs
@@ -27,7 +27,7 @@ use crate::offset::{byte_to_cp, cp_to_byte};
 // LiteralNode
 // ----------------------------------------------------------------
 
-#[pyclass(name = "LiteralNode", module = "abnf_rust._ext")]
+#[pyclass(name = "LiteralNode", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyLiteralNode {
     #[pyo3(get)]
@@ -53,7 +53,7 @@ impl PyLiteralNode {
     /// Always an empty list — terminal nodes have no children.
     #[getter]
     fn children<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
-        PyList::empty_bound(py)
+        PyList::empty(py)
     }
 
     fn __repr__(&self) -> String {
@@ -134,8 +134,8 @@ impl PyNode {
     }
 
     #[getter]
-    fn children<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
-        PyList::new_bound(py, &self.children)
+    fn children<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        PyList::new(py, &self.children)
     }
 
     fn __repr__(&self) -> String {
@@ -234,8 +234,8 @@ impl PyMatch {
     }
 
     #[getter]
-    fn nodes<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
-        PyList::new_bound(py, &self.nodes)
+    fn nodes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        PyList::new(py, &self.nodes)
     }
 
     fn __hash__(&self) -> u64 {
@@ -285,7 +285,7 @@ pub fn py_match_to_rust(py_match: &Bound<'_, PyAny>, source: &str) -> PyResult<M
     let start = cp_to_byte(source, cp_start);
     let nodes_py = py_match.getattr("nodes")?;
     let mut nodes: NodeList = SmallVec::new();
-    for item in nodes_py.iter()? {
+    for item in nodes_py.try_iter()? {
         let item = item?;
         nodes.push(py_to_node_kind(&item, source)?);
     }
@@ -301,7 +301,7 @@ fn py_to_node_kind(obj: &Bound<'_, PyAny>, source: &str) -> PyResult<NodeKind> {
     //
     // Terminal `offset`/`length` are code-point units on the Python
     // side and byte units on the Rust side; translate via `source`.
-    if let Ok(lit) = obj.downcast::<PyLiteralNode>() {
+    if let Ok(lit) = obj.cast::<PyLiteralNode>() {
         let lit = lit.borrow();
         let arc: Arc<str> = Arc::from(lit.value.as_str());
         let byte_offset = cp_to_byte(source, lit.offset);
@@ -333,7 +333,7 @@ fn py_to_node_kind(obj: &Bound<'_, PyAny>, source: &str) -> PyResult<NodeKind> {
     let name: String = obj.getattr("name")?.extract()?;
     let children_py = obj.getattr("children")?;
     let mut children: Vec<NodeKind> = Vec::new();
-    for item in children_py.iter()? {
+    for item in children_py.try_iter()? {
         let item = item?;
         children.push(py_to_node_kind(&item, source)?);
     }

--- a/packages/abnf-rust/rust/pyo3/src/parsers.rs
+++ b/packages/abnf-rust/rust/pyo3/src/parsers.rs
@@ -24,7 +24,7 @@ use crate::iter::{lparse_iter, LparseIter};
 // Repeat (config object)
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Repeat", module = "abnf_rust._ext")]
+#[pyclass(name = "Repeat", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyRepeat {
     #[pyo3(get)]
@@ -60,7 +60,7 @@ impl PyRepeat {
 // Alternation
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Alternation", module = "abnf_rust._ext")]
+#[pyclass(name = "Alternation", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyAlternation {
     pub inner: ArcParser,
@@ -107,7 +107,7 @@ impl PyAlternation {
 // Concatenation
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Concatenation", module = "abnf_rust._ext")]
+#[pyclass(name = "Concatenation", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyConcatenation {
     pub inner: ArcParser,
@@ -139,7 +139,7 @@ impl PyConcatenation {
 // Repetition
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Repetition", module = "abnf_rust._ext")]
+#[pyclass(name = "Repetition", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyRepetition {
     pub inner: ArcParser,
@@ -170,7 +170,7 @@ impl PyRepetition {
 // Option
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Option", module = "abnf_rust._ext")]
+#[pyclass(name = "Option", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyOption {
     pub inner: ArcParser,
@@ -201,7 +201,7 @@ impl PyOption {
 // Literal
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Literal", module = "abnf_rust._ext")]
+#[pyclass(name = "Literal", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyLiteral {
     pub inner: ArcParser,
@@ -257,10 +257,13 @@ impl PyLiteral {
         Ok(match &lit.kind {
             LiteralKind::String { value, .. } => {
                 let s: &str = value.as_ref();
-                s.into_py(py)
+                s.into_pyobject(py)?.into_any().unbind()
             }
             LiteralKind::Range { lo, hi, .. } => {
-                (lo.to_string(), hi.to_string()).into_py(py)
+                (lo.to_string(), hi.to_string())
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind()
             }
         })
     }
@@ -270,7 +273,7 @@ impl PyLiteral {
 // Prose
 // ----------------------------------------------------------------
 
-#[pyclass(name = "Prose", module = "abnf_rust._ext")]
+#[pyclass(name = "Prose", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyProse {
     pub inner: ArcParser,
@@ -312,22 +315,22 @@ impl PyProse {
 /// Python `Rule` instance) that exposes a `lparse(source, start)`
 /// method.
 pub fn extract_parser(obj: &Bound<'_, PyAny>) -> PyResult<ArcParser> {
-    if let Ok(p) = obj.downcast::<PyAlternation>() {
+    if let Ok(p) = obj.cast::<PyAlternation>() {
         return Ok(p.borrow().inner.clone());
     }
-    if let Ok(p) = obj.downcast::<PyConcatenation>() {
+    if let Ok(p) = obj.cast::<PyConcatenation>() {
         return Ok(p.borrow().inner.clone());
     }
-    if let Ok(p) = obj.downcast::<PyRepetition>() {
+    if let Ok(p) = obj.cast::<PyRepetition>() {
         return Ok(p.borrow().inner.clone());
     }
-    if let Ok(p) = obj.downcast::<PyOption>() {
+    if let Ok(p) = obj.cast::<PyOption>() {
         return Ok(p.borrow().inner.clone());
     }
-    if let Ok(p) = obj.downcast::<PyLiteral>() {
+    if let Ok(p) = obj.cast::<PyLiteral>() {
         return Ok(p.borrow().inner.clone());
     }
-    if let Ok(p) = obj.downcast::<PyProse>() {
+    if let Ok(p) = obj.cast::<PyProse>() {
         return Ok(p.borrow().inner.clone());
     }
     // If the value is a Python Rule (or anything else carrying a


### PR DESCRIPTION
Supersedes #112. That Dependabot PR bumps `pyo3` 0.22.6 → 0.29.0 but touches only `Cargo.toml`/`Cargo.lock`, so the `abnf-rust` bindings fail to compile against the new API and every **Rust backend** CI job fails. This PR carries the same version bump **plus** the binding migration so it actually builds and passes.

## Why the jump is mechanical
The bindings already used the **Bound API** — they just used pyo3 0.22's transitional names that 0.23–0.29 renamed/tightened. No GIL-refs rewrite was needed. Changes (5 files):

| Old (0.22) | New (0.29) |
|---|---|
| `Python::with_gil` | `Python::attach` |
| `Bound::downcast[_into]` | `Bound::cast[_into]` |
| `Bound<PyAny>::iter` | `::try_iter` |
| `Python::import_bound` | `::import` |
| `PyErr::from_value_bound` | `::from_value` |
| `PyList::{empty,new}_bound` | `::{empty,new}` (`new` now returns `PyResult` → the two getters return `PyResult`) |
| `PyErr::matches` (infallible) | now fallible → conservative `unwrap_or(false)` |
| `&str` / tuple `.into_py(py)` | `.into_pyobject(py)?.into_any().unbind()` |

The 8 `Clone`-deriving pyclasses are opted into `from_py_object` to **preserve** the current `FromPyObject` behavior (pyo3 0.29 makes that derive opt-in). No behavior change.

## Security context
The two RustSec advisories fixed in pyo3 0.29 — missing `Sync` bound on `PyCFunction::new_closure`, and an OOB read in `BoundListIterator`/`BoundTupleIterator::nth_back` — **are not reachable from `abnf-rust`** (neither API is used). So the open Dependabot pyo3 alerts were not exploitable here. Landing the bump is still worthwhile: it clears the alerts and unlocks Python 3.15 support.

## Verification (local)
- `cargo check --workspace`: **0 errors, 0 warnings** on pyo3 0.29
- maturin wheel builds and installs
- Rust backend active (`abnf.parser._BACKEND == 'rust'`)
- `pytest --ignore=tests/fuzz --ignore=tests/benchmarks`: **1179 passed, 1 skipped**

## After merge
Close #112 (Dependabot will stop re-proposing once this lands the bump). The `dependabot.yml` `ignore` rule already treats pyo3 bumps as deliberate migrations, so this stays a manual, reviewed task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
