### PR TITLE
Release 2.5.1: migrate abnf-rust to pyo3 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.5.1
+
+* Migrate the `abnf-rust` bindings from pyo3 0.22 to pyo3 0.29.  This
+  is an internal API migration only (the pyo3 `Bound` API rename:
+  `from_value_bound` -> `from_value`, `import_bound` -> `import`,
+  `downcast_into` -> `cast_into`); there is no change to the public
+  API or to parser behavior in either package.
+
+* Security / supply-chain hygiene: the pyo3 0.22 dependency shipped
+  in `abnf-rust` 2.5.0 carried two RustSec advisories —
+  RUSTSEC-2025-0020 (risk of buffer overflow in
+  `PyString::from_object`) and RUSTSEC-2026-0177 (missing `Sync`
+  bound on `PyCFunction::new_closure` closures).  `abnf-rust` never
+  called either API, so prior releases were not exploitable through
+  it; the bump to 0.29 clears both advisories so `cargo audit` and
+  SBOM scanners report the dependency tree clean.
+
+* The pure-Python `abnf` package has no source changes in this
+  release.  It is republished at 2.5.1 only to keep the
+  version-locked `abnf` / `abnf-rust` pair resolvable, since both
+  publish together from the same `v*` tag.
+
 ## 2.5.0
 
 * Add an optional Rust-backed parser engine.  Install via


### PR DESCRIPTION
## Summary

Patch release driven by the `abnf-rust` pyo3 0.22 → 0.29 migration (#114). Internal binding migration only (the pyo3 `Bound` API rename: `from_value_bound`→`from_value`, `import_bound`→`import`, `downcast_into`→`cast_into`) — **no public API or parser behavior change** in either package.

## Why release

`abnf-rust` 2.5.0 shipped pyo3 0.22, which `cargo audit` flags for two RustSec advisories:

- **RUSTSEC-2025-0020** — buffer overflow risk in `PyString::from_object`
- **RUSTSEC-2026-0177** — missing `Sync` bound on `PyCFunction::new_closure` closures

`abnf-rust` never called either API, so prior releases were **not exploitable** through it. The bump to pyo3 0.29 clears both so `cargo audit` and SBOM scanners report the dependency tree clean — relevant now that the release workflow emits SBOM + PEP 740 attestations.

Pure-Python `abnf` has **no source changes**; it is republished at 2.5.1 only to keep the version-locked `abnf` / `abnf-rust` pair resolvable (both publish from the same `v*` tag).

## Verification

| Check | Result |
|---|---|
| `cargo audit`, pyo3 0.22 lockfile (2.5.0) | 2 vulns (RUSTSEC-2025-0020, -2026-0177) |
| `cargo audit`, pyo3 0.29 lockfile (HEAD) | clean |
| abnf-rust wheel build vs pyo3 0.29 (macos-arm64, abi3-py310) | clean, no warnings |
| Python suite, Rust backend active | 1179 passed, 1 skipped, 0 failures |
| `cargo test --workspace` | 41 passed, 0 failed |

## Release steps after merge

1. Merge this PR to `master`.
2. Push tag `v2.5.1` → [release.yml](.github/workflows/release.yml) builds both packages and publishes to TestPyPI then PyPI via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)