### PR TITLE
Add grammar and parsers for RFC 7838 (HTTP Alternative Services)

### DIFF
--- a/src/abnf/grammars/rfc7838.py
+++ b/src/abnf/grammars/rfc7838.py
@@ -1,0 +1,49 @@
+"""
+Collected rules from RFC 7838
+https://tools.ietf.org/html/rfc7838
+"""
+
+from typing import ClassVar
+
+from abnf.parser import Rule as _Rule
+
+from . import rfc7230
+from .misc import load_grammar_rules
+
+
+@load_grammar_rules(
+    [
+        ("OWS", rfc7230.Rule("OWS")),
+        ("token", rfc7230.Rule("token")),
+        ("quoted-string", rfc7230.Rule("quoted-string")),
+        ("uri-host", rfc7230.Rule("uri-host")),
+        ("port", rfc7230.Rule("port")),
+    ]
+)
+class Rule(_Rule):
+    """Rules from RFC 7838.
+
+    Note: RFC 7838 Section 3.1 requires that the ALPN protocol name in
+    ``protocol-id`` be percent-encoded for any octet that is not a valid
+    ``token`` character, using uppercase hexadecimal digits. That constraint
+    applies to the *content* of the name and is not expressible in ABNF, so
+    ``protocol-id`` is defined here simply as ``token``, matching the RFC's
+    own grammar.
+    """
+
+    grammar: ClassVar[list[str] | str] = [
+        # Alt-Svc = clear / 1#alt-value ; 1#element expanded per RFC 7230 Section 7
+        'Alt-Svc       = clear / ( *( "," OWS ) alt-value *( OWS "," [ OWS alt-value ] ) )',
+        'clear         = %s"clear"',
+        'alt-value     = alternative *( OWS ";" OWS parameter )',
+        'alternative   = protocol-id "=" alt-authority',
+        "protocol-id   = token",
+        "alt-authority = quoted-string",
+        'parameter     = token "=" ( token / quoted-string )',
+        'Alt-Used      = uri-host [ ":" port ]',
+        # OWS           = <OWS, see [RFC7230], Section 3.2.3>
+        # token         = <token, see [RFC7230], Section 3.2.6>
+        # quoted-string = <quoted-string, see [RFC7230], Section 3.2.6>
+        # uri-host      = <uri-host, see [RFC7230], Section 2.7>
+        # port          = <port, see [RFC7230], Section 2.7>
+    ]

--- a/tests/test_rfc7838.py
+++ b/tests/test_rfc7838.py
@@ -1,0 +1,25 @@
+import pytest
+
+from abnf.grammars import rfc7838
+
+
+@pytest.mark.parametrize("field_value", [
+    'clear',
+    'h2="alt.example.com:443"; ma=2592000',
+    'h2=":443"',
+    'h2="alt.example.com:443", h2=":443"',
+    'h3-25=":443"; ma=3600; persist=1',
+    'h2="alt.example.com:8000"; ma=60, h2=":443"; ma=300',
+])
+def test_rfc7838_alt_svc(field_value):
+    assert rfc7838.Rule("Alt-Svc").parse_all(field_value)
+
+
+@pytest.mark.parametrize("field_value", [
+    'alt.example.com:443',
+    'alt.example.com',
+    '192.0.2.1:443',
+    '[2001:db8::1]:443',
+])
+def test_rfc7838_alt_used(field_value):
+    assert rfc7838.Rule("Alt-Used").parse_all(field_value)


### PR DESCRIPTION
Closes #133.

Adds `abnf.grammars.rfc7838` with rules for the `Alt-Svc` and `Alt-Used` headers from RFC 7838 (§3, §5), building on core rules imported from RFC 7230.

## Details

- **Imported from RFC 7230:** `OWS`, `token`, `quoted-string`, `uri-host`, `port` (following the `rfc7239` import pattern).
- **`1#alt-value`** — the HTTP list operator (RFC 7230 §7) is hand-expanded to the lenient form `*( "," OWS ) alt-value *( OWS "," [ OWS alt-value ] )`, matching how RFC 7230's own list-valued headers are written in this repo.
- **`clear = %s"clear"`** uses the RFC 7405 case-sensitive literal.
- **`protocol-id`** is defined as plain `token`; RFC 7838 §3.1's uppercase percent-encoding requirement is a content constraint not expressible in ABNF, noted in the class docstring.

## Tests

`tests/test_rfc7838.py` — 10 parametrized cases covering `Alt-Svc` (the issue's `h2="alt.example.com:443"; ma=2592000` example, `clear`, multi-value lists, params) and `Alt-Used` (host, host:port, IPv4, IPv6-literal). All pass; `ruff` and `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
