### PR TITLE
Add grammar and parsers for RFC 7240 (Prefer Header for HTTP)

### DIFF
--- a/src/abnf/grammars/rfc7240.py
+++ b/src/abnf/grammars/rfc7240.py
@@ -1,0 +1,36 @@
+"""
+Collected rules from RFC 7240
+https://tools.ietf.org/html/rfc7240
+"""
+
+from typing import ClassVar
+
+from abnf.parser import Rule as _Rule
+
+from . import rfc7230
+from .misc import load_grammar_rules
+
+
+@load_grammar_rules(
+    [
+        ("token", rfc7230.Rule("token")),
+        ("quoted-string", rfc7230.Rule("quoted-string")),
+        ("OWS", rfc7230.Rule("OWS")),
+        ("BWS", rfc7230.Rule("BWS")),
+    ]
+)
+class Rule(_Rule):
+    """Rules from RFC 7240."""
+
+    grammar: ClassVar[list[str] | str] = [
+        # 1#preference expanded per RFC 7230, Section 7.
+        'Prefer = "Prefer" ":" OWS preference *( OWS "," OWS preference )',
+        'preference = token [ BWS "=" BWS word ] *( OWS ";" [ OWS parameter ] )',
+        'parameter = token [ BWS "=" BWS word ]',
+        "word = token / quoted-string",
+        'Preference-Applied = "Preference-Applied" ":" OWS preference *( OWS "," OWS preference )',
+        # OWS           = <OWS, see [RFC7230], Section 3.2.3>
+        # BWS           = <BWS, see [RFC7230], Section 3.2.3>
+        # token         = <token, see [RFC7230], Section 3.2.6>
+        # quoted-string = <quoted-string, see [RFC7230], Section 3.2.6>
+    ]

--- a/tests/test_rfc7240.py
+++ b/tests/test_rfc7240.py
@@ -1,0 +1,38 @@
+import pytest
+
+from abnf.grammars import rfc7240
+
+
+@pytest.mark.parametrize("field_value", [
+    "Prefer: respond-async",
+    "Prefer: respond-async, wait=100",
+    "Prefer: wait=100",
+    "Prefer: return=representation",
+    "Prefer: return=minimal",
+    "Prefer: handling=strict",
+    "Prefer: handling=lenient",
+    "Prefer: return=representation; wait=10",
+    'Prefer: foo; bar; baz=quux',
+    'Prefer: lenient, respond-async',
+    ])
+def test_rfc7240_prefer(field_value):
+    assert rfc7240.Rule("Prefer").parse_all(field_value)
+
+
+@pytest.mark.parametrize("field_value", [
+    "Preference-Applied: return=representation",
+    "Preference-Applied: return=minimal",
+    "Preference-Applied: return=representation, wait=10",
+    ])
+def test_rfc7240_preference_applied(field_value):
+    assert rfc7240.Rule("Preference-Applied").parse_all(field_value)
+
+
+@pytest.mark.parametrize("src", [
+    "return=representation",
+    "wait=100",
+    "respond-async",
+    'foo="bar baz"',
+    ])
+def test_rfc7240_preference(src):
+    assert rfc7240.Rule("preference").parse_all(src)


### PR DESCRIPTION
Adds `abnf.grammars.rfc7240` implementing **RFC 7240 — Prefer Header for HTTP**, requested in #134 to support a downstream `http-headers` project.

## What's included

- **`src/abnf/grammars/rfc7240.py`** — rules for the `Prefer` and `Preference-Applied` headers, plus `preference`, `parameter`, and `word`. Core rules (`token`, `quoted-string`, `OWS`, `BWS`) are imported from `rfc7230`, matching the pattern used by `rfc7239`/`rfc6266`.
- **`tests/test_rfc7240.py`** — 17 parametrized tests exercising the examples from RFC 7240 §2 and §4.1–4.5, covering the `Prefer`/`Preference-Applied` headers and the bare `preference` rule.

## Design notes

- The `1#preference` list operator (not valid RFC 5234 ABNF) is expanded to `preference *( OWS "," OWS preference )`, following the precedent set by `rfc7239`'s `Forwarded` rule.
- The `Prefer` / `Preference-Applied` rules include the field name and `":"` exactly as written in RFC 7240 (as `rfc6266` does for `Content-Disposition`), with `OWS` after the colon so real-world values like `Prefer: return=representation` parse. Consumers that have already split off the field name can parse a bare value with the `preference` rule.

## Testing

- New module: 17 passed.
- Full suite (excluding `fuzz`/`benchmarks`): 1306 passed, 1 skipped.
- Pre-commit (ruff, pyright, check-manifest) and the pre-push `tox` matrix passed.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
