### PR TITLE
Add grammar and parsers for RFC 6797 (HTTP Strict Transport Security)

### DIFF
--- a/src/abnf/grammars/rfc6797.py
+++ b/src/abnf/grammars/rfc6797.py
@@ -1,0 +1,41 @@
+"""
+Collected rules from RFC 6797
+https://www.rfc-editor.org/rfc/rfc6797.html
+"""
+
+from typing import ClassVar
+
+from abnf.parser import Rule as _Rule
+
+from . import rfc7230
+from .misc import load_grammar_rules
+
+
+@load_grammar_rules(
+    [
+        ("token", rfc7230.Rule("token")),
+        ("quoted-string", rfc7230.Rule("quoted-string")),
+        ("OWS", rfc7230.Rule("OWS")),
+    ]
+)
+class Rule(_Rule):
+    """Rules from RFC 6797.
+
+    RFC 6797, Section 6.1 defines token and quoted-string by reference to
+    RFC 2616, Section 2.2; the functionally equivalent RFC 7230 definitions
+    are used here.  Per RFC 2616's implied *LWS rule, OWS is inserted around
+    the ":" and ";" delimiters so that header field values such as
+    'max-age=31536000; includeSubDomains' parse.  The "|" of the RFC 6797
+    directive-value rule is written as "/" per RFC 5234.
+    """
+
+    grammar: ClassVar[list[str] | str] = [
+        'Strict-Transport-Security = "Strict-Transport-Security" ":" OWS '
+        '[ directive ] *( OWS ";" OWS [ directive ] )',
+        'directive = directive-name [ "=" directive-value ]',
+        "directive-name = token",
+        "directive-value = token / quoted-string",
+        # token         = <token, see [RFC2616], Section 2.2>
+        # quoted-string = <quoted-string, see [RFC2616], Section 2.2>
+        # OWS           = <OWS, see [RFC7230], Section 3.2.3>
+    ]

--- a/tests/test_rfc6797.py
+++ b/tests/test_rfc6797.py
@@ -1,0 +1,24 @@
+import pytest
+
+from abnf.grammars import rfc6797
+
+
+@pytest.mark.parametrize("field_value", [
+    "Strict-Transport-Security: max-age=31536000",
+    "Strict-Transport-Security: max-age=31536000; includeSubDomains",
+    "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload",
+    'Strict-Transport-Security: max-age="31536000"',
+    "Strict-Transport-Security: max-age=0",
+    "Strict-Transport-Security:max-age=31536000;includeSubDomains",
+])
+def test_rfc6797_sts(field_value):
+    assert rfc6797.Rule("Strict-Transport-Security").parse_all(field_value)
+
+
+@pytest.mark.parametrize("src", [
+    "max-age=31536000",
+    "includeSubDomains",
+    'foo="bar"',
+])
+def test_rfc6797_directive(src):
+    assert rfc6797.Rule("directive").parse_all(src)


### PR DESCRIPTION
Adds an `abnf.grammars.rfc6797` module implementing the `Strict-Transport-Security` header field grammar from [RFC 6797, Section 6.1](https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1) (HTTP Strict Transport Security).

Closes #132

## Grammar

```
Strict-Transport-Security = "Strict-Transport-Security" ":" OWS [ directive ] *( OWS ";" OWS [ directive ] )
directive                 = directive-name [ "=" directive-value ]
directive-name            = token
directive-value           = token / quoted-string
```

## Notes on the implementation

- **`token` / `quoted-string` / `OWS` are imported from RFC 7230.** RFC 6797 §6.1 cites RFC 2616 §2.2 for `token` and `quoted-string`, but `rfc2616.py` only defines `token`. The RFC 7230 rules are the functional successors and are what the other modern header modules (`rfc7240`, `rfc7239`) already use.
- **`OWS` is inserted around the `:` and `;` delimiters.** The literal RFC 6797 grammar has no whitespace, which would reject real-world values such as `max-age=31536000; includeSubDomains`. This is permitted by RFC 2616 §2.1's implied `*LWS` rule, and follows the precedent set by `rfc6265.py`. Documented in the module docstring.
- `directive-value = token / quoted-string` is unambiguous under the default longest-match alternation, since `quoted-string` begins with `DQUOTE` (not a `tchar`).

## Tests

`tests/test_rfc6797.py` — 9 parametrized cases covering `max-age`, `includeSubDomains`, `preload`, the quoted `max-age="31536000"` form, `max-age=0`, and a whitespace-free variant. All pass; `ruff` and `pyright` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
