### PR TITLE
Fix cors Origin rule to accept "null"; warn on rule redefinition

### DIFF
--- a/src/abnf/__init__.py
+++ b/src/abnf/__init__.py
@@ -3,15 +3,24 @@
 
 from importlib.metadata import PackageNotFoundError, metadata  # pragma: no cover
 
-from abnf.parser import GrammarError, LiteralNode, Node, NodeVisitor, ParseError, Rule
+from abnf.parser import (
+    GrammarError,
+    GrammarWarning,
+    LiteralNode,
+    Node,
+    NodeVisitor,
+    ParseError,
+    Rule,
+)
 
 __all__ = [
-    "Rule",
-    "Node",
+    "GrammarError",
+    "GrammarWarning",
     "LiteralNode",
+    "Node",
     "NodeVisitor",
     "ParseError",
-    "GrammarError",
+    "Rule",
     "__version__",
 ]
 

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import typing
+import warnings
 from collections import OrderedDict
 from collections.abc import Generator
 from weakref import WeakSet
@@ -857,6 +858,11 @@ class GrammarError(Exception):
     """Raised in response to errors detected in the grammar."""
 
 
+class GrammarWarning(UserWarning):
+    """Emitted for suspect (but not fatal) conditions detected in a grammar,
+    such as a rule that is defined more than once with '='."""
+
+
 #### Bootstrappery ####
 # To get parsing for parser generation started, the ABNF grammar from RFC 5234 and
 # RFC 7405, plus the core rules from RFC 5234, are defined ab initio.
@@ -1370,6 +1376,31 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
         # this assertion tells mypy that rule should actually be an object. Without, mypy
         # returns 'error: <nothing> has no attribute "definition"'
         assert rule
+        # A plain '=' redefinition silently discards the rule's existing definition
+        # (RFC 5234, Section 3.3, allows incremental definition only via '=/').  Because
+        # ABNF rule names are case-insensitive, names differing only in case -- e.g.
+        # 'Origin' and 'origin' -- resolve to the same rule and collide this way too.
+        if defined_as == "=" and getattr(rule, "_definition", None) is not None:
+            new_name = next(
+                (c.value for c in node.children if c.name == "rulename"), rule.name
+            )
+            existing_name = rule.name
+            # This branch is reached only when the names already match under
+            # casefold, so an inexact spelling match means they differ only in case.
+            detail = (
+                f"redefines {existing_name!r}"
+                if new_name == existing_name
+                else (
+                    f"redefines {existing_name!r}, whose name differs only in case "
+                    "(ABNF rule names are case-insensitive)"
+                )
+            )
+            warnings.warn(
+                f"rule {new_name!r} {detail}; the earlier definition is discarded. "
+                "Use '=/' to add an incremental alternative instead of '='.",
+                GrammarWarning,
+                stacklevel=2,
+            )
         rule.definition = (
             elements if defined_as == "=" else Alternation(rule.definition, elements)
         )

--- a/src/abnf/grammars/cors.py
+++ b/src/abnf/grammars/cors.py
@@ -1,39 +1,76 @@
 """
-Collected rules from fetch standard
-https://fetch.spec.whatwg.org/#cors-protocol
+Collected rules from the Fetch standard.
+https://fetch.spec.whatwg.org/#origin-header
+https://fetch.spec.whatwg.org/#http-responses
+
+Note that Fetch defines a self-contained grammar for a serialized origin
+(serialized-scheme / serialized-host / serialized-port and friends) rather than
+reusing scheme / host / port from RFC 3986.  The Origin request header value is
+either such a serialized origin or the case-sensitive string "null" (the
+serialization of an opaque origin), so Origin admits "null".
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
-from . import rfc3986, rfc7230, rfc7234
+from . import rfc9110, rfc9111
 from .misc import load_grammar_rules
 
 
 @load_grammar_rules(
     [
-        ("scheme", rfc3986.Rule("scheme")),
-        ("host", rfc3986.Rule("host")),
-        ("port", rfc3986.Rule("port")),
-        ("method", rfc7230.Rule("method")),
-        ("field-name", rfc7230.Rule("field-name")),
-        ("OWS", rfc7230.Rule("OWS")),
-        ("delta-seconds", rfc7234.Rule("delta-seconds")),
+        ("method", rfc9110.Rule("method")),
+        ("field-name", rfc9110.Rule("field-name")),
+        ("OWS", rfc9110.Rule("OWS")),
+        ("delta-seconds", rfc9111.Rule("delta-seconds")),
     ]
 )
 class Rule(_Rule):
-    grammar: ClassVar[Union[list[str], str]] = [
+    """Rules from the Fetch standard."""
+
+    # Fetch defines the CORS response headers using the "#rule" list extension
+    # from RFC 9110, Section 5.6.1.  That extension is not part of RFC 5234
+    # ABNF, so the affected rules are expanded here to their equivalent
+    # RFC 5234 form:
+    #     1#field-name = field-name *( OWS "," OWS field-name )
+    #      #field-name = [ field-name *( OWS "," OWS field-name ) ]
+    #      #method     = [ method *( OWS "," OWS method ) ]
+    grammar: ClassVar[list[str] | str] = [
+        'serialized-ipv4 = dec-octet "." dec-octet "." dec-octet "." dec-octet',
+        'dec-octet = DIGIT / %x31-39 DIGIT / "1" 2DIGIT / "2" %x30-34 DIGIT / "25" %x30-35',
+        'serialized-ipv6 = 7( h16 ":" ) h16 '
+        '/ "::" 5( h16 ":" ) h16 '
+        '/ [ h16 ] "::" 4( h16 ":" ) h16 '
+        '/ [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) h16 '
+        '/ [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) h16 '
+        '/ [ *3( h16 ":" ) h16 ] "::" h16 ":" h16 '
+        '/ [ *4( h16 ":" ) h16 ] "::" h16 '
+        '/ [ *5( h16 ":" ) h16 ] "::"',
+        'h16 = "0" / ( non-zero-hex 0*3hex )',
+        "non-zero-hex = %x31-39 / %x61-66",
+        "hex = %x30-39 / %x61-66",
+        "lower-alpha = %x61-7A",
+        "lower-alphanum = lower-alpha / DIGIT",
+        'domain-label = lower-alphanum / ( lower-alphanum *( lower-alphanum / "-" ) lower-alphanum )',
+        'serialized-domain = *( domain-label "." ) domain-label',
+        'serialized-scheme = lower-alpha *( lower-alphanum / "+" / "-" / "." )',
+        'serialized-host = serialized-ipv4 / "[" serialized-ipv6 "]" / serialized-domain',
+        "serialized-port = 1*5DIGIT",
+        'serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]',
+        'origin-or-null = serialized-origin / %s"null"',
         "Origin = origin-or-null",
-        "origin-or-null = origin / %x6E.75.6C.6C",
-        'origin = scheme "://" host [ ":" port ]',
         "Access-Control-Request-Method = method",
         'Access-Control-Request-Headers = field-name *( OWS "," OWS field-name )',
         'wildcard = "*"',
         "Access-Control-Allow-Origin = origin-or-null / wildcard",
-        "Access-Control-Allow-Credentials = %x74.72.75.65",
+        'Access-Control-Allow-Credentials = %s"true"',
         'Access-Control-Expose-Headers = [ field-name *( OWS "," OWS field-name ) ]',
         "Access-Control-Max-Age = delta-seconds",
         'Access-Control-Allow-Methods = [ method *( OWS "," OWS method ) ]',
         'Access-Control-Allow-Headers = [ field-name *( OWS "," OWS field-name ) ]',
+        # method       = <method, see [RFC9110], Section 9.1>
+        # field-name   = <field-name, see [RFC9110], Section 5.1>
+        # OWS          = <OWS, see [RFC9110], Section 5.6.3>
+        # delta-seconds = <delta-seconds, see [RFC9111], Section 1.2.2>
     ]

--- a/src/abnf/parser.py
+++ b/src/abnf/parser.py
@@ -25,6 +25,7 @@ from abnf import _parser_python as _py
 from abnf._parser_python import (
     ABNFGrammarRule,
     GrammarError,
+    GrammarWarning,
     Matches,
     MatchSet,
     Nodes,
@@ -121,6 +122,7 @@ __all__ = [
     "CharValNodeVisitor",
     "Concatenation",
     "GrammarError",
+    "GrammarWarning",
     "Literal",
     "LiteralNode",
     "Match",

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,82 @@
+import pytest
+
+from abnf import ParseError
+from abnf.grammars import cors
+
+
+@pytest.mark.parametrize("field_value", [
+    "null",  # opaque origin serializes to the ASCII string "null"
+    "https://example.com",
+    "https://example.com:8080",
+    "http://foo.invalid",
+    "https://127.0.0.1:443",
+    "https://[2001:db8::1]:8080",
+    "https://[::1]",
+    "ftp://a.b.c",
+])
+def test_cors_origin(field_value):
+    assert cors.Rule("Origin").parse_all(field_value)
+
+
+@pytest.mark.parametrize("field_value", [
+    "NULL",  # origin-or-null "null" is case-sensitive (%s"null")
+    "https://Example.com",  # serialized-domain is lowercase only
+    "example.com",  # missing scheme "://"
+    "",
+])
+def test_cors_origin_fail(field_value):
+    with pytest.raises(ParseError):
+        cors.Rule("Origin").parse_all(field_value)
+
+
+def test_cors_serialized_origin_rejects_null():
+    # "null" is only accepted at the origin-or-null level, not as a serialized origin.
+    with pytest.raises(ParseError):
+        cors.Rule("serialized-origin").parse_all("null")
+
+
+@pytest.mark.parametrize("field_value", [
+    "null",
+    "*",
+    "https://example.com",
+])
+def test_cors_allow_origin(field_value):
+    assert cors.Rule("Access-Control-Allow-Origin").parse_all(field_value)
+
+
+@pytest.mark.parametrize("field_value", ["true"])
+def test_cors_allow_credentials(field_value):
+    assert cors.Rule("Access-Control-Allow-Credentials").parse_all(field_value)
+
+
+@pytest.mark.parametrize("field_value", ["false", "TRUE"])
+def test_cors_allow_credentials_fail(field_value):
+    with pytest.raises(ParseError):
+        cors.Rule("Access-Control-Allow-Credentials").parse_all(field_value)
+
+
+def test_cors_request_method():
+    assert cors.Rule("Access-Control-Request-Method").parse_all("GET")
+
+
+@pytest.mark.parametrize("field_value", ["X-Custom", "X-A, X-B"])
+def test_cors_request_headers(field_value):
+    assert cors.Rule("Access-Control-Request-Headers").parse_all(field_value)
+
+
+@pytest.mark.parametrize("field_value", [
+    "",  # #field-name permits an empty list
+    "X-A",
+    "X-A, X-B",
+])
+def test_cors_expose_headers(field_value):
+    assert cors.Rule("Access-Control-Expose-Headers").parse_all(field_value)
+
+
+def test_cors_max_age():
+    assert cors.Rule("Access-Control-Max-Age").parse_all("3600")
+
+
+@pytest.mark.parametrize("field_value", ["", "GET", "GET, POST"])
+def test_cors_allow_methods(field_value):
+    assert cors.Rule("Access-Control-Allow-Methods").parse_all(field_value)

--- a/tests/test_grammar_warning.py
+++ b/tests/test_grammar_warning.py
@@ -1,0 +1,56 @@
+import warnings
+
+import pytest
+
+from abnf.parser import GrammarWarning, ParseError, Rule
+
+
+def test_case_insensitive_redefinition_warns():
+    class R(Rule):
+        pass
+
+    R.create("Origin = %x61")
+    with pytest.warns(GrammarWarning, match="differs only in case"):
+        R.create("origin = %x62")
+
+
+def test_same_name_redefinition_warns():
+    class R(Rule):
+        pass
+
+    R.create("foo = %x61")
+    with pytest.warns(GrammarWarning, match="redefines 'foo'"):
+        R.create("foo = %x62")
+
+
+def test_incremental_alternative_does_not_warn():
+    class R(Rule):
+        pass
+
+    R.create("foo = %x61")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", GrammarWarning)
+        R.create("foo =/ %x62")
+
+
+def test_forward_reference_does_not_warn():
+    class R(Rule):
+        pass
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", GrammarWarning)
+        R.create("bar = foo")
+        R.create("foo = %x61")
+
+
+def test_redefinition_keeps_latest_definition():
+    class R(Rule):
+        pass
+
+    R.create("foo = %x61")
+    with pytest.warns(GrammarWarning):
+        R.create("foo = %x62")
+    # 'b' (%x62), the later definition, is what remains.
+    assert R("foo").parse_all("b")
+    with pytest.raises(ParseError):
+        R("foo").parse_all("a")


### PR DESCRIPTION
Fixes #135.

## Problem

`cors.Rule("Origin").parse_all("null")` raised `ParseError`, even though `Origin: null` is a spec-valid header value (the serialization of an opaque origin).

The root cause was a **rule-name collision**, not a missing alternative. ABNF rule names are case-insensitive (RFC 5234 §2.1), so the module's `Origin = origin-or-null` and `origin = scheme "://" host [ ":" port ]` resolved to the *same* rule — the serialized-origin definition silently clobbered the header definition, leaving `Origin` unable to match `null`.

## Fix

Replace the origin grammar with the **current Fetch standard** grammar. Fetch defines a self-contained serialized origin (`serialized-scheme` / `serialized-host` with IPv4, bracketed IPv6, and lowercase-domain forms / `serialized-port`) and names it distinctly, so there is no collision:

```
serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
origin-or-null    = serialized-origin / %s"null"   ; case-sensitive
Origin            = origin-or-null
```

- Case-sensitive literals now use RFC 7405 `%s` strings (`%s"null"`, `%s"true"`), matching the spec's `; case-sensitive` annotations.
- Imports realign to the RFC 9110 / 9111 productions Fetch now references (`method`, `field-name`, `OWS`, `delta-seconds`); the RFC 3986 import is dropped since the origin grammar is now self-contained.
- The RFC 9110 `#rule` list operator isn't core RFC 5234 ABNF (unsupported by this library), so the affected headers stay expanded to their RFC 5234 form, documented in a comment — same as before.

## Prevention: `GrammarWarning`

Added a public `GrammarWarning` emitted from `visit_rule` when a rule is redefined with `=` (rather than `=/`). This surfaces exactly this class of collision — including names differing **only in case** — at grammar-load time:

> rule 'origin' redefines 'Origin', whose name differs only in case (ABNF rule names are case-insensitive); the earlier definition is discarded. Use '=/' to add an incremental alternative instead of '='.

It stays silent on the two legitimate patterns (`=/` incremental alternatives, and forward references). Verified all 33 existing grammar modules load without triggering it.

## Tests

- `tests/test_cors.py` (new) — `Origin` accepts `null` / domain / IPv4 / IPv6 / port, case-sensitivity of `%s"null"`, `serialized-origin` rejecting `null`, and every CORS header including empty `#`-lists.
- `tests/test_grammar_warning.py` (new) — collision (case + same-name), silent `=/`, silent forward-reference, latest-definition-wins.
- Full suite (excl. fuzz/benchmarks): 1360 passed, 1 skipped. `ruff` + `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
