### PR TITLE
Cleanup: drop black/isort for ruff, modernize formatting, tidy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache
 .coverage
+.DS_Store
 .mypy*
 *.pyc
 __pycache__

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ tox                                                   # Matrix across Python 3.1
 **Linting & Formatting:**
 ```bash
 ruff check src/abnf    # Lint
-black src/abnf         # Format
+ruff format src/abnf   # Format
 pyright                # Type check
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ ignore = [
     "tests/notes",
 ]
 
+[tool.pytest.ini_options]
+norecursedirs = [".tox", "venv"]
+testpaths = ["tests"]
+
 [tool.pyright]
 pythonVersion = "3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,6 @@ rust = [
     'abnf-rust>=2.5,<3',
 ]
 
-[tool.black]
-
 [tool.check-manifest]
 ignore = [
     # The packages/abnf-rust subtree builds the companion `abnf-rust`
@@ -73,9 +71,6 @@ ignore = [
     "packages/**",
     "tests/notes",
 ]
-
-[tool.isort]
-profile = "black"
 
 [tool.pyright]
 pythonVersion = "3.10"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-norecursedirs = .tox venv/
-testpaths = tests/

--- a/src/abnf/__init__.py
+++ b/src/abnf/__init__.py
@@ -1,6 +1,5 @@
 """Parser generator for ABNF grammars."""
 
-
 from importlib.metadata import PackageNotFoundError, metadata  # pragma: no cover
 
 from abnf.parser import (

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -758,10 +758,8 @@ class Node:
         return self._value
 
     def __str__(self) -> str:
-        return "Node(name={}, children=[{}])".format(
-            self.name,
-            ", ".join(x.__str__() for x in self.children),
-        )
+        children = ", ".join(x.__str__() for x in self.children)
+        return f"Node(name={self.name}, children=[{children}])"
 
     def __eq__(self, other: typing.Any):
         return (
@@ -789,11 +787,8 @@ class LiteralNode:
         return []
 
     def __str__(self):
-        return 'Node(name={}, offset={}, value="{}")'.format(
-            self.name,
-            self.offset,
-            self.value.replace("\r", r"\r").replace("\n", r"\n"),
-        )
+        value = self.value.replace("\r", r"\r").replace("\n", r"\n")
+        return f'Node(name={self.name}, offset={self.offset}, value="{value}")'
 
     def __eq__(self, other: typing.Any):
         return (

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -36,7 +36,7 @@ class Match:
 
     def __str__(self):
         return (
-            f'Match(value={"".join(n.value for n in self.nodes)}, start={self.start})'
+            f"Match(value={''.join(n.value for n in self.nodes)}, start={self.start})"
         )
 
     def __eq__(self, __o: object) -> bool:
@@ -338,9 +338,7 @@ class Repetition:
                         if m.start in seen_starts or m.start in new_seen_starts:
                             continue
                         new_seen_starts.add(m.start)
-                        new_match_set.append(
-                            Match(match.nodes + m.nodes, m.start)
-                        )
+                        new_match_set.append(Match(match.nodes + m.nodes, m.start))
                 except ParseError:
                     pass
 
@@ -384,7 +382,7 @@ class Option:
 
 
 class Literal:
-    """Represents a terminal literal value."""    
+    """Represents a terminal literal value."""
 
     def __init__(
         self,
@@ -717,9 +715,7 @@ class Rule:
         cls.load_grammar(src)
 
     @classmethod
-    def get(
-        cls: type[T], name: str, default: T | None = None
-    ) -> Rule | None:
+    def get(cls: type[T], name: str, default: T | None = None) -> Rule | None:
         """Retrieves Rule by name.  If a Rule object matching name is found, it is returned.
         Otherwise default is returned, and no Rule object is
         created, as would be the case when invoking Rule(name).

--- a/src/abnf/grammars/misc.py
+++ b/src/abnf/grammars/misc.py
@@ -1,6 +1,5 @@
 """Miscellaneous functions."""
 
-
 from abnf.parser import ABNFGrammarNodeVisitor, ABNFGrammarRule, Rule
 
 __all__ = ["load_grammar_rulelist", "load_grammar_rules"]

--- a/src/abnf/grammars/misc.py
+++ b/src/abnf/grammars/misc.py
@@ -1,12 +1,12 @@
 """Miscellaneous functions."""
 
-from typing import Optional
 
 from abnf.parser import ABNFGrammarNodeVisitor, ABNFGrammarRule, Rule
 
-__all__ = ['load_grammar_rules', 'load_grammar_rulelist']
+__all__ = ["load_grammar_rulelist", "load_grammar_rules"]
 
-def load_grammar_rules(imported_rules: Optional[list[tuple[str, Rule]]] = None):
+
+def load_grammar_rules(imported_rules: list[tuple[str, Rule]] | None = None):
     """A decorator that loads grammar rules following class declaration.  The code assumes
     that cls is a Rule subclass with a grammar attribute.
     The imported_rules parameter allows one to import rules from other modules. For examples,
@@ -17,7 +17,7 @@ def load_grammar_rules(imported_rules: Optional[list[tuple[str, Rule]]] = None):
         """The function returned by decorator."""
 
         if isinstance(cls.grammar, str):
-            msg = 'This decorator must be used with a grammar of type list'
+            msg = "This decorator must be used with a grammar of type list"
             raise TypeError(msg)
 
         for src in cls.grammar:
@@ -30,7 +30,7 @@ def load_grammar_rules(imported_rules: Optional[list[tuple[str, Rule]]] = None):
     return rule_decorator
 
 
-def load_grammar_rulelist(imported_rules: Optional[list[tuple[str, Rule]]] = None):
+def load_grammar_rulelist(imported_rules: list[tuple[str, Rule]] | None = None):
     """A decorator that loads grammar rules following class declaration.  The code assumes
     that cls is a Rule subclass with a grammar attribute.
     The imported_rules parameter allows one to import rules from other modules. For examples,
@@ -40,7 +40,7 @@ def load_grammar_rulelist(imported_rules: Optional[list[tuple[str, Rule]]] = Non
     def rule_decorator(cls: type[Rule]):
         """The function returned by decorator."""
         assert isinstance(cls.grammar, str)
-        src = cls.grammar.rstrip().replace("\r", "").replace("\n", "\r\n") + '\r\n'
+        src = cls.grammar.rstrip().replace("\r", "").replace("\n", "\r\n") + "\r\n"
         node = ABNFGrammarRule("rulelist").parse_all(src)
         visitor = ABNFGrammarNodeVisitor(cls)
         visitor.visit(node)

--- a/src/abnf/grammars/rfc2616.py
+++ b/src/abnf/grammars/rfc2616.py
@@ -2,11 +2,10 @@
 Collected rules from RFC 2616.
 https://www.rfc-editor.org/rfc/rfc2616.html
 
-Though RFC 2616 is largely obsolete, some later RFCs, not obsolete, 
+Though RFC 2616 is largely obsolete, some later RFCs, not obsolete,
 still incorporate grammar from RFC 2616; in particular, RFC 6265.
 Here we collect grammar from RFC 2616 as needed for use with other RFC grammars.
 """
-
 
 from abnf.parser import Rule as _Rule
 
@@ -16,10 +15,10 @@ from .misc import load_grammar_rulelist
 @load_grammar_rulelist()
 class Rule(_Rule):
     """Rule objects generated from ABNF in RFC 2616.
-    Note that token rule is implemented from prose value in RFC 2616, and | was 
+    Note that token rule is implemented from prose value in RFC 2616, and | was
     replaced by / as expected by RFC 5234."""
 
-    grammar = r'''
+    grammar = r"""
 HTTP-date    = rfc1123-date / rfc850-date / asctime-date
 rfc1123-date = wkday "," SP date1 SP time SP "GMT"
 rfc850-date  = weekday "," SP date2 SP time SP "GMT"
@@ -41,5 +40,4 @@ month        = "Jan" / "Feb" / "Mar" / "Apr"
             / "Sep" / "Oct" / "Nov" / "Dec"
 
 token = 1*( %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39 / %x41-5A / %x5E-7A / %x7C )
-'''
-
+"""

--- a/src/abnf/grammars/rfc3339.py
+++ b/src/abnf/grammars/rfc3339.py
@@ -3,7 +3,7 @@ Collected rules from RFC 3339, Appendix A.
 https://datatracker.ietf.org/doc/html/rfc3339
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -14,7 +14,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 3339."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "date-fullyear   = 4DIGIT",
         "date-month      = 2DIGIT  ; 01-12",
         "date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on\

--- a/src/abnf/grammars/rfc3629.py
+++ b/src/abnf/grammars/rfc3629.py
@@ -2,7 +2,8 @@
 Collected rules from RFC 3629, Appendix A.
 https://datatracker.ietf.org/doc/html/rfc3629
 """
-from typing import ClassVar, Union
+
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -13,14 +14,14 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 3629."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
-        'UTF8-octets = *( UTF8-char )',
-        'UTF8-char   = UTF8-1 / UTF8-2 / UTF8-3 / UTF8-4',
-        'UTF8-1      = %x00-7F',
-        'UTF8-2      = %xC2-DF UTF8-tail',
-        'UTF8-3      = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /\
-                        %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )',
-        'UTF8-4      = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /\
-                        %xF4 %x80-8F 2( UTF8-tail )',
-        'UTF8-tail   = %x80-BF',
-        ]
+    grammar: ClassVar[list[str] | str] = [
+        "UTF8-octets = *( UTF8-char )",
+        "UTF8-char   = UTF8-1 / UTF8-2 / UTF8-3 / UTF8-4",
+        "UTF8-1      = %x00-7F",
+        "UTF8-2      = %xC2-DF UTF8-tail",
+        "UTF8-3      = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /\
+                        %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )",
+        "UTF8-4      = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /\
+                        %xF4 %x80-8F 2( UTF8-tail )",
+        "UTF8-tail   = %x80-BF",
+    ]

--- a/src/abnf/grammars/rfc3986.py
+++ b/src/abnf/grammars/rfc3986.py
@@ -3,7 +3,7 @@ Collected rules from RFC 3986, Appendix A.
 https://tools.ietf.org/html/rfc3986#appendix-A
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -14,7 +14,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 3986."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]',
         'hier-part = "//" authority path-abempty / path-absolute / path-rootless / path-empty',
         "URI-reference = URI / relative-ref",
@@ -56,4 +56,4 @@ class Rule(_Rule):
 
 
 # see https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2 .
-Rule('host').first_match_alternation = True
+Rule("host").first_match_alternation = True

--- a/src/abnf/grammars/rfc4647.py
+++ b/src/abnf/grammars/rfc4647.py
@@ -3,7 +3,7 @@ Collected rules from RFC 4647
 https://tools.ietf.org/html/rfc4647
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -14,7 +14,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rule objects generated from ABNF in RFC 4647."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'language-range = (1*8ALPHA *("-" 1*8alphanum)) / "*"',
         "alphanum = ALPHA / DIGIT",
         'extended-language-range = (1*8ALPHA / "*") *("-" (1*8alphanum / "*"))',

--- a/src/abnf/grammars/rfc5234.py
+++ b/src/abnf/grammars/rfc5234.py
@@ -5,7 +5,7 @@ Collected rules from RFC 5234
 https://tools.ietf.org/html/rfc5234
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -16,7 +16,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rule objects generated from ABNF in RFC 5234."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "rulelist = 1*( rule / (*c-wsp c-nl) )",
         "rule = rulename defined-as elements c-nl\
                                         ; continues if next line starts\

--- a/src/abnf/grammars/rfc5322.py
+++ b/src/abnf/grammars/rfc5322.py
@@ -3,7 +3,7 @@ Collected rules from RFC 5322
 https://tools.ietf.org/html/rfc5322
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -14,7 +14,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rule objects generated from ABNF in RFC 5322."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'quoted-pair = ("\\" (VCHAR / WSP)) / obs-qp',
         "FWS = ([*WSP CRLF] 1*WSP) / obs-FWS ",
         "ctext = %d33-39 / %d42-91 / %d93-126 / obs-ctext",
@@ -102,7 +102,7 @@ class Rule(_Rule):
         'obs-qp = "\\" (%d0 / obs-NO-WS-CTL / LF / CR)',
         "obs-body = *((*LF *CR *((%d0 / text) *LF *CR)) / CRLF)",
         # See https://www.rfc-editor.org/errata/eid1905.
-        #"obs-unstruct = *((*LF *CR *(obs-utext *LF *CR)) / FWS)",
+        # "obs-unstruct = *((*LF *CR *(obs-utext *LF *CR)) / FWS)",
         "obs-unstruct = *( (*CR 1*(obs-utext / FWS)) / 1*LF ) *CR",
         'obs-phrase = word *(word / "." / CFWS)',
         'obs-phrase-list = [phrase / CFWS] *("," [phrase / CFWS])',
@@ -153,4 +153,4 @@ class Rule(_Rule):
     ]
 
 
-#Rule('unstructured').first_match_alternation = True
+# Rule('unstructured').first_match_alternation = True

--- a/src/abnf/grammars/rfc5646.py
+++ b/src/abnf/grammars/rfc5646.py
@@ -3,7 +3,7 @@ Collected rules from RFC 5646
 https://tools.ietf.org/html/rfc5646
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -14,7 +14,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 5646."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "Language-Tag = langtag / privateuse / grandfathered",
         'langtag = language ["-" script] ["-" region] *("-" variant) *("-" extension) ["-" privateuse]',
         'language = 2*3ALPHA ["-" extlang] / 4ALPHA / 5*8ALPHA',

--- a/src/abnf/grammars/rfc5987.py
+++ b/src/abnf/grammars/rfc5987.py
@@ -3,7 +3,7 @@ Collected rules from RFC 5987
 https://tools.ietf.org/html/rfc5987
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -13,52 +13,39 @@ from .misc import load_grammar_rules
 
 @load_grammar_rules(
     [
-    ("quoted-string", rfc7230.Rule("quoted-string")),
-    ("token", rfc7230.Rule("token")),
-    ("language", rfc5646.Rule("language-tag")),
+        ("quoted-string", rfc7230.Rule("quoted-string")),
+        ("token", rfc7230.Rule("token")),
+        ("language", rfc5646.Rule("language-tag")),
     ]
 )
 class Rule(_Rule):
     """Rules from RFC 5987."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
-    #'#parameter     = attribute LWSP "=" LWSP value',
-    #'attribute     = token',
-    'value         = token / quoted-string',
-
-    #quoted-string = <quoted-string, defined in [RFC2616], Section 2.2>
-    #token         = <token, defined in [RFC2616], Section 2.2>
-
-    # In order to include character set and language information, this
-    # specification modifies the RFC 2616 grammar to be:
-
-    'parameter     = reg-parameter / ext-parameter',
-
-    'reg-parameter = parmname LWSP "=" LWSP value',
-
-    'ext-parameter = parmname "*" LWSP "=" LWSP ext-value',
-
-    'parmname      = 1*attr-char',
-
-    'ext-value     = charset  "\'" [ language ] "\'" value-chars',
-                   # like RFC 2231's <extended-initial-value>
-                   # (see [RFC2231], Section 7)
-
-    'charset       = "UTF-8" / "ISO-8859-1" / mime-charset',
-
-    'mime-charset  = 1*mime-charsetc',
-    'mime-charsetc = ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "+" / "-" / "^" / "_" / "`" / "{" / "}" / "~"',
-                   # as <mime-charset> in Section 2.3 of [RFC2978]
-                   # except that the single quote is not included
-                   # SHOULD be registered in the IANA charset registry
-
-     #language      = <Language-Tag, defined in [RFC5646], Section 2.1>
-
-    'value-chars   = *( pct-encoded / attr-char )',
-
-    'pct-encoded   = "%" HEXDIG HEXDIG',
-                   # see [RFC3986], Section 2.1
-
-    'attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"',
-                   # token except ( "*" / "'" / "%" )
+    grammar: ClassVar[list[str] | str] = [
+        #'#parameter     = attribute LWSP "=" LWSP value',
+        #'attribute     = token',
+        "value         = token / quoted-string",
+        # quoted-string = <quoted-string, defined in [RFC2616], Section 2.2>
+        # token         = <token, defined in [RFC2616], Section 2.2>
+        # In order to include character set and language information, this
+        # specification modifies the RFC 2616 grammar to be:
+        "parameter     = reg-parameter / ext-parameter",
+        'reg-parameter = parmname LWSP "=" LWSP value',
+        'ext-parameter = parmname "*" LWSP "=" LWSP ext-value',
+        "parmname      = 1*attr-char",
+        'ext-value     = charset  "\'" [ language ] "\'" value-chars',
+        # like RFC 2231's <extended-initial-value>
+        # (see [RFC2231], Section 7)
+        'charset       = "UTF-8" / "ISO-8859-1" / mime-charset',
+        "mime-charset  = 1*mime-charsetc",
+        'mime-charsetc = ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "+" / "-" / "^" / "_" / "`" / "{" / "}" / "~"',
+        # as <mime-charset> in Section 2.3 of [RFC2978]
+        # except that the single quote is not included
+        # SHOULD be registered in the IANA charset registry
+        # language      = <Language-Tag, defined in [RFC5646], Section 2.1>
+        "value-chars   = *( pct-encoded / attr-char )",
+        'pct-encoded   = "%" HEXDIG HEXDIG',
+        # see [RFC3986], Section 2.1
+        'attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"',
+        # token except ( "*" / "'" / "%" )
     ]

--- a/src/abnf/grammars/rfc6266.py
+++ b/src/abnf/grammars/rfc6266.py
@@ -3,7 +3,7 @@ Collected rules from RFC 6266
 https://tools.ietf.org/html/rfc6266
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -26,7 +26,7 @@ class Rule(_Rule):
     # uses | instead of / for alternation, and white space here and there is implicit in RFC 2616.
     # The grammar below is updated to follow RFC 5234.
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'content-disposition = "Content-Disposition" ":" OWS disposition-type *(OWS  ";"  OWS disposition-parm )',
         'disposition-type    = "inline" / "attachment" / disp-ext-type',  # case-insensitive
         "disp-ext-type       = token",

--- a/src/abnf/grammars/rfc7230.py
+++ b/src/abnf/grammars/rfc7230.py
@@ -2,11 +2,11 @@
 Collected rules from RFC 7230, Appendix B.
 https://tools.ietf.org/html/rfc7230#appendix-B
 
-Note that this RFC is obsolete as of June 2022, replaced by 
+Note that this RFC is obsolete as of June 2022, replaced by
 https://www.rfc-editor.org/rfc/rfc9110.
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -32,7 +32,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Parser rules for grammar from RFC 7230."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "BWS = OWS",
         'Connection = *( "," OWS ) connection-option *( OWS "," [ OWS connection-option ] )',
         "Content-Length = 1*DIGIT",

--- a/src/abnf/grammars/rfc7231.py
+++ b/src/abnf/grammars/rfc7231.py
@@ -2,11 +2,11 @@
 Collected rules from RFC 7231, Appendix c, D.
 https://tools.ietf.org/html/rfc7231#appendix-C
 
-Note that this RFC is obsolete as of June 2022, replaced by 
+Note that this RFC is obsolete as of June 2022, replaced by
 https://www.rfc-editor.org/rfc/rfc9110.
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -35,7 +35,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 7231."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'Accept = [ ( "," / ( media-range [ accept-params ] ) ) *( OWS "," [ OWS ( media-range [ accept-params ] ) ] ) ]',
         'Accept-Charset = *( "," OWS ) ( ( charset / "*" ) [ weight ] ) *( OWS "," [ OWS ( ( charset / "*" ) [ weight ] ) ] )',
         'Accept-Encoding = [ ( "," / ( codings [ weight ] ) ) *( OWS "," [ OWS ( codings [ weight ] ) ] ) ]',

--- a/src/abnf/grammars/rfc7232.py
+++ b/src/abnf/grammars/rfc7232.py
@@ -2,11 +2,11 @@
 Collected rules from RFC 7232
 https://tools.ietf.org/html/rfc7232
 
-Note that this RFC is obsolete as of June 2022, replaced by 
+Note that this RFC is obsolete as of June 2022, replaced by
 https://www.rfc-editor.org/rfc/rfc9110.
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -24,7 +24,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 7232."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "ETag = entity-tag",
         # HTTP-date = <HTTP-date, see [RFC7231], Section 7.1.1.1>
         'If-Match = "*" / ( *( "," OWS ) entity-tag *( OWS "," [ OWS entity-tag ] ) )',

--- a/src/abnf/grammars/rfc7233.py
+++ b/src/abnf/grammars/rfc7233.py
@@ -2,11 +2,11 @@
 Collected rules from RFC 7233
 https://tools.ietf.org/html/rfc7233
 
-Note that this RFC is obsolete as of June 2022, replaced by 
+Note that this RFC is obsolete as of June 2022, replaced by
 https://www.rfc-editor.org/rfc/rfc9110.
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -25,7 +25,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 7233."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "Accept-Ranges = acceptable-ranges",
         "Content-Range = byte-content-range / other-content-range",
         # HTTP-date = <HTTP-date, see [RFC7231], Section 7.1.1.1>',

--- a/src/abnf/grammars/rfc7234.py
+++ b/src/abnf/grammars/rfc7234.py
@@ -3,7 +3,7 @@ Collected rules from RFC 7234
 https://tools.ietf.org/html/rfc7234
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -26,7 +26,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 7234."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "Age = delta-seconds",
         'Cache-Control = *( "," OWS ) cache-directive *( OWS "," [ OWS cache-directive ] )',
         "Expires = HTTP-date",

--- a/src/abnf/grammars/rfc7235.py
+++ b/src/abnf/grammars/rfc7235.py
@@ -2,11 +2,11 @@
 Collected rules from RFC 7235
 https://tools.ietf.org/html/rfc7235
 
-Note that this RFC is obsolete as of June 2022, replaced by 
+Note that this RFC is obsolete as of June 2022, replaced by
 https://www.rfc-editor.org/rfc/rfc9110.
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -25,7 +25,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 7235."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "Authorization = credentials",
         # BWS = <BWS, see [RFC7230], Section 3.2.3>',
         # OWS = <OWS, see [RFC7230], Section 3.2.3>',

--- a/src/abnf/grammars/rfc7239.py
+++ b/src/abnf/grammars/rfc7239.py
@@ -25,7 +25,7 @@ class Rule(_Rule):
         'Forwarded         = forwarded-element *( OWS "," OWS forwarded-element )',
         'forwarded-element = [ forwarded-pair ] *( ";" [ forwarded-pair ] )',
         'forwarded-pair    = token "=" value',
-        'value             = token / quoted-string',
+        "value             = token / quoted-string",
         # OWS              = <OWS, see [RFC7230], Section 3.2.3>',
         # token            = <token, see [RFC7230], Section 3.2.6>',
         # quoted-string    = <quoted-string, see [RFC7230], Section 3.2.6>',

--- a/src/abnf/grammars/rfc7405.py
+++ b/src/abnf/grammars/rfc7405.py
@@ -5,7 +5,7 @@ Collected rules from RFC 7405
 https://tools.ietf.org/html/rfc7405
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -23,7 +23,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rule objects generated from ABNF in RFC 7405."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         "char-val = case-insensitive-string /\
                            case-sensitive-string",
         'case-insensitive-string =\

--- a/src/abnf/grammars/rfc7489.py
+++ b/src/abnf/grammars/rfc7489.py
@@ -3,7 +3,7 @@ Collected rules from RFC 7489
 https://tools.ietf.org/html/rfc7489
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -11,41 +11,32 @@ from . import rfc5322
 from .misc import load_grammar_rules
 
 
-@load_grammar_rules(
-    [
-        ("addr-spec", rfc5322.Rule("addr-spec"))
-    ]
-)
-
-
-
+@load_grammar_rules([("addr-spec", rfc5322.Rule("addr-spec"))])
 class Rule(_Rule):
     """Rules from RFC 7489."""
 
-    '''grammar = [
+    """grammar = [
         # This value is an integer in [0,100]
         # Originaly 'dmarc-percent = "pct" *WSP "=" *WSP 1*3DIGIT'. 'pct=999' is following the grammar but is wrong.
         'dmarc-record = dmarc-version dmarc-sep dmarc-request *( dmarc-sep ( dmarc-srequest / dmarc-auri / dmarc-furi / dmarc-aspf / dmarc-adkim / dmarc-aspf dmarc-ainterval / dmarc-fo / dmarc-percent ) ) dmarc-sep'
 
-    ]'''
-    grammar: ClassVar[Union[list[str], str]] = [
-            'URI = %x6D %x61 %x69 %x6C %x74 %x6F %x3A addr-spec',
-            'dmarc-uri = URI [ "!" 1*DIGIT [ "k" / "m" / "g" / "t" ] ]',
-            
-            'dmarc-version = "v" *WSP "=" *WSP %x44 %x4d %x41 %x52 %x43 %x31',
-            'dmarc-sep = *WSP %x3b *WSP',
-            'dmarc-request = "p" *WSP "=" *WSP ( "none" / "quarantine" / "reject" )',
-            'dmarc-srequest  = "sp" *WSP "=" *WSP ( "none" / "quarantine" / "reject" )',
-            'dmarc-auri = "rua" *WSP "=" *WSP dmarc-uri *(*WSP "," *WSP dmarc-uri)',
-            'dmarc-furi  = "ruf" *WSP "=" *WSP dmarc-uri *(*WSP "," *WSP dmarc-uri)',
-            'dmarc-adkim = "adkim" *WSP "=" *WSP ( "r" / "s" )',
-            'dmarc-aspf = "aspf" *WSP "=" *WSP ( "r" / "s" )',
-            'dmarc-ainterval = "ri" *WSP "=" *WSP 1*DIGIT',
-            'dmarc-fo = "fo" *WSP "=" *WSP ( "0" / "1" / "d" / "s" ) *(*WSP ":" *WSP ( "0" / "1" / "d" / "s" ))',
-
-            # Keyword for 'rf' in the rfc are only limited to afrf 'dmarc-rfmt = "rf"  *WSP "=" *WSP Keyword *(*WSP ":" Keyword)',
-            'dmarc-rfmt = "rf"  *WSP "=" *WSP "afrf"',
-            # Originaly 'dmarc-percent = "pct" *WSP "=" *WSP 1*3DIGIT'. 'pct=999' is following the grammar but it is wrong
-            'dmarc-percent = "pct" *WSP "=" *WSP ( "100" / 1*2DIGIT / "0" )',
-            'dmarc-record = dmarc-version dmarc-sep dmarc-request *(dmarc-sep (dmarc-srequest / dmarc-auri / dmarc-furi / dmarc-aspf / dmarc-adkim / dmarc-aspf / dmarc-ainterval / dmarc-fo / dmarc-percent / dmarc-rfmt)) dmarc-sep'
-        ]
+    ]"""
+    grammar: ClassVar[list[str] | str] = [
+        "URI = %x6D %x61 %x69 %x6C %x74 %x6F %x3A addr-spec",
+        'dmarc-uri = URI [ "!" 1*DIGIT [ "k" / "m" / "g" / "t" ] ]',
+        'dmarc-version = "v" *WSP "=" *WSP %x44 %x4d %x41 %x52 %x43 %x31',
+        "dmarc-sep = *WSP %x3b *WSP",
+        'dmarc-request = "p" *WSP "=" *WSP ( "none" / "quarantine" / "reject" )',
+        'dmarc-srequest  = "sp" *WSP "=" *WSP ( "none" / "quarantine" / "reject" )',
+        'dmarc-auri = "rua" *WSP "=" *WSP dmarc-uri *(*WSP "," *WSP dmarc-uri)',
+        'dmarc-furi  = "ruf" *WSP "=" *WSP dmarc-uri *(*WSP "," *WSP dmarc-uri)',
+        'dmarc-adkim = "adkim" *WSP "=" *WSP ( "r" / "s" )',
+        'dmarc-aspf = "aspf" *WSP "=" *WSP ( "r" / "s" )',
+        'dmarc-ainterval = "ri" *WSP "=" *WSP 1*DIGIT',
+        'dmarc-fo = "fo" *WSP "=" *WSP ( "0" / "1" / "d" / "s" ) *(*WSP ":" *WSP ( "0" / "1" / "d" / "s" ))',
+        # Keyword for 'rf' in the rfc are only limited to afrf 'dmarc-rfmt = "rf"  *WSP "=" *WSP Keyword *(*WSP ":" Keyword)',
+        'dmarc-rfmt = "rf"  *WSP "=" *WSP "afrf"',
+        # Originaly 'dmarc-percent = "pct" *WSP "=" *WSP 1*3DIGIT'. 'pct=999' is following the grammar but it is wrong
+        'dmarc-percent = "pct" *WSP "=" *WSP ( "100" / 1*2DIGIT / "0" )',
+        "dmarc-record = dmarc-version dmarc-sep dmarc-request *(dmarc-sep (dmarc-srequest / dmarc-auri / dmarc-furi / dmarc-aspf / dmarc-adkim / dmarc-aspf / dmarc-ainterval / dmarc-fo / dmarc-percent / dmarc-rfmt)) dmarc-sep",
+    ]

--- a/src/abnf/grammars/rfc8187.py
+++ b/src/abnf/grammars/rfc8187.py
@@ -3,7 +3,7 @@ Collected rules from RFC 8187
 https://tools.ietf.org/html/rfc8187
 """
 
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -15,7 +15,7 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules from RFC 8187."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'ext-value = charset "\'" [ language ] "\'" value-chars',
         'charset = "UTF-8" / mime-charset',
         "mime-charset = 1*mime-charsetc",

--- a/src/abnf/grammars/rfc9051.py
+++ b/src/abnf/grammars/rfc9051.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.grammars import rfc3629
 from abnf.parser import Rule as _Rule
@@ -21,24 +21,21 @@ from .misc import load_grammar_rules
 class Rule(_Rule):
     """Rules for RFC 9051 parsing."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
+    grammar: ClassVar[list[str] | str] = [
         'address = "(" addr-name SP addr-adl SP addr-mailbox SP addr-host ")"',
         "addr-adl = nstring",
         "addr-host = nstring",
         "addr-mailbox = nstring",
         "addr-name = nstring",
-        'append = "APPEND" SP mailbox [SP flag-list] [SP date-time] SP '
-        "literal",
+        'append = "APPEND" SP mailbox [SP flag-list] [SP date-time] SP literal',
         "append-uid = uniqueid",
         "astring = 1*ASTRING-CHAR / string",
         "ASTRING-CHAR = ATOM-CHAR / resp-specials",
         "atom = 1*ATOM-CHAR",
-        "ATOM-CHAR = %x21 / %x23-24 / %x26-27 / %x2B-39 / %x3B-5B / "
-        "%x5E-7A / %x7C",
+        "ATOM-CHAR = %x21 / %x23-24 / %x26-27 / %x2B-39 / %x3B-5B / %x5E-7A / %x7C",
         'atom-specials = "(" / ")" / "{" / SP / CTL / list-wildcards / '
         "quoted-specials / resp-specials",
-        'authenticate = "AUTHENTICATE" SP auth-type [SP initial-resp] '
-        "*(CRLF base64)",
+        'authenticate = "AUTHENTICATE" SP auth-type [SP initial-resp] *(CRLF base64)',
         "auth-type = atom",
         "base64 = *(4base64-char) [base64-terminal]",
         'base64-char = ALPHA / DIGIT / "+" / "/"',
@@ -62,8 +59,7 @@ class Rule(_Rule):
         "body-fld-lines = number64",
         "body-fld-md5 = nstring",
         "body-fld-octets = number",
-        'body-fld-param = "(" string SP string *(SP string SP string) ")" / '
-        "nil",
+        'body-fld-param = "(" string SP string *(SP string SP string) ")" / nil',
         "body-type-1part = (body-type-basic / body-type-msg / body-type-text) "
         "[SP body-ext-1part]",
         "body-type-basic = media-basic SP body-fields",
@@ -172,16 +168,14 @@ class Rule(_Rule):
         "DQUOTE / nil) SP mailbox [SP mbx-list-extended]",
         'mbx-list-extended = "(" [mbox-list-extended-item '
         '*(SP mbox-list-extended-item)] ")"',
-        "mbox-list-extended-item = mbox-list-extended-item-tag SP "
-        "tagged-ext-val",
+        "mbox-list-extended-item = mbox-list-extended-item-tag SP tagged-ext-val",
         "mbox-list-extended-item-tag = astring",
         "mbox-or-pat =  list-mailbox / patterns",
         "mbx-list-flags = *(mbx-list-oflag SP) mbx-list-sflag "
         "*(SP mbx-list-oflag) / mbx-list-oflag *(SP mbx-list-oflag)",
         'mbx-list-oflag = "\\Noinferiors" / child-mbox-flag / '
         '"\\Subscribed" / "\\Remote" / flag-extension',
-        'mbx-list-sflag = "\\NonExistent" / "\\Noselect" / "\\Marked" / '
-        '"\\Unmarked"',
+        'mbx-list-sflag = "\\NonExistent" / "\\Noselect" / "\\Marked" / "\\Unmarked"',
         'media-basic = ((DQUOTE ("APPLICATION" / "AUDIO" / "IMAGE" / '
         '"FONT" / "MESSAGE" / "MODEL" / "VIDEO") DQUOTE) / string) SP '
         "media-subtype",
@@ -206,10 +200,8 @@ class Rule(_Rule):
         "[namespace-response-extensions] "
         '")"',
         "namespace-response-extensions = *namespace-response-extension",
-        'namespace-response-extension = SP string SP "(" string '
-        '*(SP string) ")"',
-        'namespace-response = "NAMESPACE" SP namespace SP namespace SP '
-        "namespace",
+        'namespace-response-extension = SP string SP "(" string *(SP string) ")"',
+        'namespace-response = "NAMESPACE" SP namespace SP namespace SP namespace',
         'nil = "NIL"',
         "nstring = string / nil",
         "number = 1*DIGIT",
@@ -261,8 +253,7 @@ class Rule(_Rule):
         '"CANNOT" / "LIMIT" / "OVERQUOTA" / "ALREADYEXISTS" / '
         '"NONEXISTENT" / "NOTSAVED" / "HASCHILDREN" / "CLOSED" / '
         '"UNKNOWN-CTE" / atom [SP 1*<any TEXT-CHAR except "]">]',
-        'return-option = "SUBSCRIBED" / "CHILDREN" / status-option / '
-        "option-extension",
+        'return-option = "SUBSCRIBED" / "CHILDREN" / status-option / option-extension',
         'search = "SEARCH" [search-return-opts] SP search-program',
         'search-correlator = SP "(" "TAG" SP tag-string ")"',
         'search-key = "ALL" / "ANSWERED" / "BCC" SP astring / "BEFORE" SP '
@@ -278,8 +269,7 @@ class Rule(_Rule):
         'sequence-set / "(" search-key *(SP search-key) ")"',
         "search-modifier-name = tagged-ext-label",
         "search-mod-params = tagged-ext-val",
-        'search-program = ["CHARSET" SP charset SP] search-key '
-        "*(SP search-key)",
+        'search-program = ["CHARSET" SP charset SP] search-key *(SP search-key)',
         "search-ret-data-ext = search-modifier-name SP search-return-value",
         'search-return-data = "MIN" SP nz-number / "MAX" SP nz-number / '
         '"ALL" SP sequence-set / "COUNT" SP number / search-ret-data-ext',
@@ -291,16 +281,14 @@ class Rule(_Rule):
         "search-return-value = tagged-ext-val",
         'section = "[" [section-spec] "]"',
         'section-binary = "[" [section-part] "]"',
-        'section-msgtext = "HEADER" / "HEADER.FIELDS" [".NOT"] SP '
-        'header-list / "TEXT"',
+        'section-msgtext = "HEADER" / "HEADER.FIELDS" [".NOT"] SP header-list / "TEXT"',
         'section-part = nz-number *("." nz-number)',
         'section-spec = section-msgtext / (section-part ["." section-text])',
         'section-text = section-msgtext / "MIME"',
         'select = "SELECT" SP mailbox',
         'seq-number = nz-number / "*"',
         'seq-range = seq-number ":" seq-number',
-        'sequence-set = (seq-number / seq-range) ["," sequence-set] / '
-        "seq-last-command",
+        'sequence-set = (seq-number / seq-range) ["," sequence-set] / seq-last-command',
         'seq-last-command = "$"',
         'status = "STATUS" SP mailbox SP "(" status-att *(SP status-att) ")"',
         'status-att = "MESSAGES" / "UIDNEXT" / "UIDVALIDITY" / "UNSEEN" / '

--- a/src/abnf/grammars/rfc9116.py
+++ b/src/abnf/grammars/rfc9116.py
@@ -1,12 +1,9 @@
-
-
 """
 Collected rules from RFC 9116
 https://www.rfc-editor.org/rfc/rfc9116
 """
 
-
-from typing import ClassVar, Union
+from typing import ClassVar
 
 from abnf.parser import Rule as _Rule
 
@@ -16,125 +13,80 @@ from .misc import load_grammar_rules
 
 @load_grammar_rules(
     [
-    ("email", rfc5322.Rule("address")),
-    ("uri", rfc3986.Rule("uri")),
-    ('field-name', rfc5322.Rule("field-name")),
-    ('unstructured', rfc5322.Rule('unstructured')),
-    ('UTF8-octets', rfc3629.Rule('UTF8-octets')),
-    ('UTF8-char', rfc3629.Rule('UTF8-char')),
-    ('UTF8-1', rfc3629.Rule('UTF8-1')),
-    ('UTF8-2', rfc3629.Rule('UTF8-2')),
-    ('UTF8-3', rfc3629.Rule('UTF8-3')),
-    ('UTF8-4', rfc3629.Rule('UTF8-4')),
-    ('UTF8-tail', rfc3629.Rule('UTF8-tail')),
-    ('lang-tag', rfc5646.Rule('langtag')),
-    ('date-time', rfc3339.Rule('date-time')),
+        ("email", rfc5322.Rule("address")),
+        ("uri", rfc3986.Rule("uri")),
+        ("field-name", rfc5322.Rule("field-name")),
+        ("unstructured", rfc5322.Rule("unstructured")),
+        ("UTF8-octets", rfc3629.Rule("UTF8-octets")),
+        ("UTF8-char", rfc3629.Rule("UTF8-char")),
+        ("UTF8-1", rfc3629.Rule("UTF8-1")),
+        ("UTF8-2", rfc3629.Rule("UTF8-2")),
+        ("UTF8-3", rfc3629.Rule("UTF8-3")),
+        ("UTF8-4", rfc3629.Rule("UTF8-4")),
+        ("UTF8-tail", rfc3629.Rule("UTF8-tail")),
+        ("lang-tag", rfc5646.Rule("langtag")),
+        ("date-time", rfc3339.Rule("date-time")),
     ]
 )
 class Rule(_Rule):
     """Rules from RFC 5987."""
 
-    grammar: ClassVar[Union[list[str], str]] = [
-        'body =  signed / unsigned',
-
-        'unsigned =  *line (contact-field eol) *line (expires-field eol) *line [lang-field eol] *line',
-        
-
+    grammar: ClassVar[list[str] | str] = [
+        "body =  signed / unsigned",
+        "unsigned =  *line (contact-field eol) *line (expires-field eol) *line [lang-field eol] *line",
         #'; signed is the production that should match the OpenPGP clearsigned',
         #'; document',
-        'signed =  cleartext-header 1*(hash-header) CRLF cleartext signature',
-
+        "signed =  cleartext-header 1*(hash-header) CRLF cleartext signature",
         'cleartext-header =  %s"-----BEGIN PGP SIGNED MESSAGE-----" CRLF',
-
         'hash-header      =  %s"Hash: " hash-alg *("," hash-alg) CRLF',
-
-        'hash-alg         =  token',
-
-        'cleartext        =  *((line-dash / line-from / line-nodash) [CR] LF)',
-
+        "hash-alg         =  token",
+        "cleartext        =  *((line-dash / line-from / line-nodash) [CR] LF)",
         'line-dash        =  ("- ") "-" *UTF8-char-not-cr',
-
         'line-from        =  ["- "] "From " *UTF8-char-not-cr',
-
         'line-nodash      =  ["- "] *UTF8-char-not-cr',
-
-        'UTF8-char-not-dash =  UTF8-1-not-dash / UTF8-2 / UTF8-3 / UTF8-4',
-        'UTF8-1-not-dash  =  %x00-2C / %x2E-7F',
-        'UTF8-char-not-cr =  UTF8-1-not-cr / UTF8-2 / UTF8-3 / UTF8-4',
-        'UTF8-1-not-cr    =  %x00-0C / %x0E-7F',
-
+        "UTF8-char-not-dash =  UTF8-1-not-dash / UTF8-2 / UTF8-3 / UTF8-4",
+        "UTF8-1-not-dash  =  %x00-2C / %x2E-7F",
+        "UTF8-char-not-cr =  UTF8-1-not-cr / UTF8-2 / UTF8-3 / UTF8-4",
+        "UTF8-1-not-cr    =  %x00-0C / %x0E-7F",
         #'; UTF8 rules from RFC 3629 -- imported above',
-
-
-        'signature        =  armor-header armor-keys CRLF signature-data armor-tail',
-
+        "signature        =  armor-header armor-keys CRLF signature-data armor-tail",
         'armor-header     =  %s"-----BEGIN PGP SIGNATURE-----" CRLF',
-
         'armor-keys       =  *(token ": " *( VCHAR / WSP ) CRLF)',
-
         'armor-tail       =  %s"-----END PGP SIGNATURE-----" CRLF',
-
         'signature-data   =  1*(1*(ALPHA / DIGIT / "=" / "+" / "/") CRLF)\
                             ; base64; see RFC 4648\
                             ; includes RFC 4880 checksum',
-
-        'line             =  [ (field / comment) ] eol',
-
-        'eol              =  *WSP [CR] LF',
-
+        "line             =  [ (field / comment) ] eol",
+        "eol              =  *WSP [CR] LF",
         #'field            =  ; optional fields\
-        'field            =  ack-field / can-field / contact-field / encryption-field / hiring-field / policy-field / ext-field',
-
+        "field            =  ack-field / can-field / contact-field / encryption-field / hiring-field / policy-field / ext-field",
         'fs               =  ":"',
-
         'comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)',
-
         'ack-field        =  "Acknowledgments" fs SP uri',
-
         'can-field        =  "Canonical" fs SP uri',
-
         'contact-field    =  "Contact" fs SP uri',
-
         'expires-field    =  "Expires" fs SP date-time',
-
         'encryption-field =  "Encryption" fs SP uri',
-
         'hiring-field     =  "Hiring" fs SP uri',
-
         'lang-field       =  "Preferred-Languages" fs SP lang-values',
-
         'policy-field     =  "Policy" fs SP uri',
-
-        #date-time        =  < imported from Section 5.6 of [RFC3339] >
-
-        #lang-tag         =  < Language-Tag from Section 2.1 of [RFC5646] >
-
+        # date-time        =  < imported from Section 5.6 of [RFC3339] >
+        # lang-tag         =  < Language-Tag from Section 2.1 of [RFC5646] >
         'lang-values      =  lang-tag *(*WSP "," *WSP lang-tag)',
-
-        #uri              =  < URI as per Section 3 of [RFC3986] >
-
-        'ext-field        =  field-name fs SP unstructured',
-
-        #field-name       =  < imported from Section 3.6.8 of [RFC5322] >
-
-        #unstructured     =  < imported from Section 3.2.5 of [RFC5322] >
-
-        #token            =  < imported from Section 5.1 of [RFC2045] >
+        # uri              =  < URI as per Section 3 of [RFC3986] >
+        "ext-field        =  field-name fs SP unstructured",
+        # field-name       =  < imported from Section 3.6.8 of [RFC5322] >
+        # unstructured     =  < imported from Section 3.2.5 of [RFC5322] >
+        # token            =  < imported from Section 5.1 of [RFC2045] >
         # definition from RFC 2045:
         # token := 1*<any (US-ASCII) CHAR except SPACE, CTLs,
         #        or tspecials>
-
         # tspecials :=  "(" / ")" / "<" / ">" / "@" /
         #           "," / ";" / ":" / "\" / <">
         #           "/" / "[" / "]" / "?" / "="
         #          ; Must be in quoted-string,
         #          ; to use within parameter values
-
-        
-        'token-char = %x21-27 / %x2A-2B / %x30-39 / %x41-5A / %x5E-7E',
-        'token = 1*token-char',
-
-
-# core rules included in this grammar are omitted.
-
+        "token-char = %x21-27 / %x2A-2B / %x30-39 / %x41-5A / %x5E-7E",
+        "token = 1*token-char",
+        # core rules included in this grammar are omitted.
     ]

--- a/src/abnf/grammars/rfc9651.py
+++ b/src/abnf/grammars/rfc9651.py
@@ -73,7 +73,9 @@ __all__ = [
 class Rule(_Rule):
     """Rules from RFC 9651, Appendix C."""
 
-    grammar: ClassVar[list[str] | str] = r"""sf-list = list-member *( OWS "," OWS list-member )
+    grammar: ClassVar[
+        list[str] | str
+    ] = r"""sf-list = list-member *( OWS "," OWS list-member )
 list-member = sf-item / inner-list
 inner-list = "(" *SP [ sf-item *( 1*SP sf-item ) *SP ] ")" parameters
 parameters = *( ";" *SP parameter )

--- a/src/abnf/typing.py
+++ b/src/abnf/typing.py
@@ -1,9 +1,8 @@
-"""Conditional typing imports are collected here, because doing the import below in 
+"""Conditional typing imports are collected here, because doing the import below in
 parser.py appears to confuse pylance, causing it to flag objects as not conforming to
 Parser protocol.  Adding Parser as a superclass of Rule leads to more odd type errors.
 The code branches on version instead of using try-except so that mypy is happy.
 """
-
 
 from typing import Protocol, runtime_checkable
 


### PR DESCRIPTION
## Summary

Project cleanup: remove the black/isort toolchain in favor of ruff, modernize a couple of string-formatting spots, and tidy repo config. No behavior changes to the parser or grammars — all edits are formatting, tooling, or type-hint modernization.

## Changes

- **Drop black and isort** — remove `[tool.black]` and `[tool.isort]` from `pyproject.toml`; ruff already handles formatting and import sorting (`I` rules). Update `CLAUDE.md` to use `ruff format`. Reformat `src/abnf` with `ruff format` and apply `ruff check --fix` auto-fixes (`typing.Union`/`Optional` → `X | Y` per the project's documented convention, `__all__` sorting).
- **Modernize string formatting** — replace two `str.format()` calls in `Node`/`LiteralNode.__str__` with f-strings.
- **Consolidate pytest config** — move `norecursedirs`/`testpaths` from `pytest.ini` into `[tool.pytest.ini_options]` and delete `pytest.ini`.
- **Ignore `.DS_Store`** — add to `.gitignore`.

## Verification

- 1360 tests pass (1 skipped); the only errors are the pre-existing benchmark suite needing the `pytest-benchmark` plugin, unrelated to this branch.
- `ruff check`, `ruff format --check`, and `pyright` all clean.
- Pre-commit hooks (ruff, pyright, check-manifest, tox) pass.
- Confirmed pytest reads `configfile: pyproject.toml` with `testpaths: tests` after the consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
