### PR TITLE
Convert RecursionError to ParseError on deeply-nested input (#144)

### DIFF
--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -658,6 +658,35 @@ class Rule:
         :raises ParseError: if source cannot be parsed using rule.
         :raises GrammarError: if rule has no definition.  This usually means that a
             non-terminal in the grammar is not defined or imported.
+
+        .. note::
+            The pure-Python backend is recursive-descent, so input nested more
+            deeply than the Python recursion limit permits is reported as a
+            ParseError rather than crashing with RecursionError.  The Rust
+            backend is not subject to this limit.  If you must parse very deeply
+            nested input on the pure-Python backend, run the parse on a worker
+            thread with a larger stack and a raised recursion limit -- both
+            levers are needed, as ``setrecursionlimit`` alone would overflow the
+            C stack::
+
+                import sys, threading
+
+                def parse_all_deep(rule, source, *, limit=100_000,
+                                   stack=256 * 1024 * 1024):
+                    threading.stack_size(stack)
+                    box = {}
+                    def run():
+                        sys.setrecursionlimit(limit)  # process-global while running
+                        try:
+                            box["node"] = rule.parse_all(source)
+                        except BaseException as exc:  # re-raised on the caller
+                            box["exc"] = exc
+                    t = threading.Thread(target=run)
+                    t.start()
+                    t.join()
+                    if "exc" in box:
+                        raise box["exc"]
+                    return box["node"]
         """
 
         node, start = self.parse(source, 0)

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -630,7 +630,19 @@ class Rule:
         # losing candidates.  If `g` yields nothing it has already
         # raised `ParseError`; the `next` here therefore never sees
         # `StopIteration` in practice.
-        longest_match = next(g)
+        try:
+            longest_match = next(g)
+        except RecursionError as exc:
+            # Deeply-nested input exhausts the Python call stack (the parser is
+            # recursive-descent).  Convert to ParseError so the documented
+            # exception contract holds instead of leaking RecursionError, and
+            # so callers guarding untrusted input with `except ParseError` are
+            # not crashed by it.  See GitHub issue #144.  `parse` is the
+            # outermost frame, so by the time RecursionError has unwound to
+            # here there is stack headroom to raise; and because RecursionError
+            # is not a ParseError, the intermediate `except ParseError` handlers
+            # in Alternation/Repetition do not swallow it on the way up.
+            raise ParseError(self, start) from exc
         return (longest_match.nodes[0], longest_match.start)
 
     def parse_all(self, source: str) -> Node:

--- a/tests/fuzz/gen_corpus.py
+++ b/tests/fuzz/gen_corpus.py
@@ -114,7 +114,6 @@ def generate_module(
         kept: list[str] = []
         rejected = 0
         too_long = 0
-        recursion_hits = 0
         mismatches: list[str] = []
         for src in candidates:
             if len(src) > MAX_INPUT_LEN:
@@ -125,14 +124,9 @@ def generate_module(
             try:
                 node = rule.parse_all(src)
             except ParseError:
+                # Includes deeply-nested input, which the parser converts to
+                # ParseError (issue #144); such inputs are simply not accepted.
                 rejected += 1
-                continue
-            except RecursionError:
-                # Deeply nested input overflows the recursive-descent parser's
-                # Python stack.  A depth limit, not a length one — the input can
-                # be short (e.g. "((((...))))").  Drop it from the corpus and
-                # report; see the design doc's robustness note.
-                recursion_hits += 1
                 continue
             if node.value == src:
                 kept.append(src)
@@ -154,8 +148,6 @@ def generate_module(
             notes.append(f"{rejected} unparseable")
         if too_long:
             notes.append(f"{too_long} over {MAX_INPUT_LEN} chars")
-        if recursion_hits:
-            notes.append(f"{recursion_hits} RecursionError")
         note = f" ({', '.join(notes)} filtered)" if notes else ""
         print(f"  {rule.name}: {len(kept)} cases{note}")
 
@@ -196,8 +188,6 @@ def build_negatives(
                     rule.parse_all(mutated)
                 except ParseError:
                     negatives.setdefault(rule_name, []).append(mutated)
-                except RecursionError:
-                    pass
                 else:
                     accepted_bugs.append((rule_name, mutated))
                 if len(negatives.get(rule_name, ())) >= NEG_PER_RULE:

--- a/tests/fuzz/test_grammar_modules.py
+++ b/tests/fuzz/test_grammar_modules.py
@@ -107,6 +107,9 @@ def test_generated_input_round_trips(module_name: str, rule_name: str):
     @settings(
         max_examples=50,
         database=None,
+        # Parse cost varies a lot across grammars (complex RFC 9051 IMAP inputs
+        # can take a few hundred ms), so the per-example deadline would flake.
+        deadline=None,
         suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.too_slow],
     )
     def check(src: str):
@@ -114,16 +117,13 @@ def test_generated_input_round_trips(module_name: str, rule_name: str):
         try:
             node = rule.parse_all(src)
         except ParseError:
-            # Grammar-derivation vs longest-match mismatch on an ambiguous rule;
-            # not a member of the language as the parser defines it.  assume(False)
-            # raises to discard the example; the return keeps `node` definitely
-            # bound for the assertion below (pyright can't see assume never returns).
-            assume(False)
-            return
-        except RecursionError:
-            # Deeply nested input overflows the pure-Python parser's stack — a
-            # known limitation, see .claude/finding-recursionerror-deep-nesting.md.
-            # Tolerated here; any *other* exception type is a real crash and fails.
+            # Grammar-derivation vs longest-match mismatch on an ambiguous rule
+            # (or deeply-nested input, which the parser converts to ParseError,
+            # issue #144); not a member of the language as the parser defines
+            # it.  assume(False) raises to discard the example; the return keeps
+            # `node` definitely bound for the assertion below (pyright can't see
+            # assume never returns).  Any *other* exception type is a real crash
+            # and fails the test.
             assume(False)
             return
         assert node.value == src
@@ -131,7 +131,7 @@ def test_generated_input_round_trips(module_name: str, rule_name: str):
     try:
         check()
     except Unsatisfiable:
-        # Every generated input was filtered (unparseable derivation, deep
-        # recursion, or over-length) — the rule is effectively ungeneratable by
-        # this walker, same as the cases gen_corpus.py skips.  Not a failure.
+        # Every generated input was filtered (unparseable derivation or
+        # over-length) — the rule is effectively ungeneratable by this walker,
+        # same as the cases gen_corpus.py skips.  Not a failure.
         pytest.skip(f"{rule_name}: no parseable input could be generated")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -145,6 +145,31 @@ def test_backtracking():
     assert "".join(n.value for n in match.nodes) == src
 
 
+def test_deeply_nested_input_does_not_leak_recursionerror():
+    """Regression for issue #144: deeply-nested input must not escape as an
+    uncaught RecursionError.  The recursive-descent pure-Python parser converts
+    it to a ParseError (the documented contract); the Rust backend parses it."""
+
+    class DeepGrammar(Rule):
+        pass
+
+    DeepGrammar.create('nested = "(" [ nested ] ")"')
+    depth = 1000
+    src = "(" * depth + ")" * depth
+
+    raised_parse_error = False
+    try:
+        DeepGrammar("nested").parse_all(src)
+    except ParseError:
+        raised_parse_error = True
+    # RecursionError is not caught here, so if the fix regresses it propagates
+    # and fails the test.
+
+    if __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "python":
+        # nesting well beyond the Python recursion limit must convert cleanly.
+        assert raised_parse_error
+
+
 def test_alternation_first_match():
     parser = Alternation(Literal("a"), Literal("ab"), first_match=True)
     result = parser.lparse("ab", 0)


### PR DESCRIPTION
Fixes #144.

The pure-Python recursive-descent parser raised an **uncaught `RecursionError`** when input nesting exceeded the Python call stack (~248 levels at the default `recursionlimit=1000`). That violates the documented `parse` / `parse_all` contract (`ParseError` / `GrammarError` only), so `try: rule.parse_all(untrusted) except ParseError:` crashes instead of handling the input — a DoS surface for any grammar with a recursive rule (nested parens/lists, comments, MIME/IMAP body structures, URIs, `Language-Tag`, …). The Rust backend was unaffected, so it was also a python/rust divergence.

## Fix

This is the issue's **option 1** (catch-and-convert): at the outermost `Rule.parse` boundary, catch `RecursionError` and re-raise as `ParseError`.

Two properties make this safe and localized:

- **`parse` is the outermost frame.** Internally the combinators recurse through `lparse`, never `parse`, so there is exactly one `parse` on the stack. By the time the `RecursionError` has unwound back up to it, the stack has headroom to construct and raise `ParseError`.
- **No handler swallows it on the way up.** `RecursionError` is not a `ParseError`, so the intermediate `except ParseError` blocks in `Alternation` / `Repetition` (which drive backtracking) let it pass straight through to `parse`.

The chained `from exc` preserves the original `RecursionError` as the cause for debuggability.

### Behaviour after the fix

| depth | pure-Python (before) | pure-Python (after) | Rust |
|------:|----------------------|---------------------|------|
| 100   | parses               | parses              | parses |
| 248   | **RecursionError**   | `ParseError`        | parses |
| 1000  | **RecursionError**   | `ParseError`        | parses |
| 2000  | **RecursionError**   | `ParseError`        | `ParseError` |

Shallow/valid nesting still parses and round-trips. Deep nesting is now a clean, catchable rejection on the pure-Python backend rather than a crash. (As noted on the issue, fully matching Rust's depth-independent acceptance would require an iterative parser — option 2 — a larger change; this restores the exception contract and removes the crash.)

## Test

Adds `test_deeply_nested_input_does_not_leak_recursionerror`: 1000-deep nesting must never leak `RecursionError` (it propagates and fails the test if it does), and on the pure-Python backend must convert to `ParseError`. Passes under both backends. Full existing suite passes unchanged.

## Follow-up commit: fuzz tooling cleanup

With deep nesting now converting to `ParseError`, the #138 fuzz suite's `RecursionError` handling is dead code, so it is removed from `gen_corpus.py` and the live discovery test (such inputs now register as ordinary "unparseable" rejections). The committed corpora are **byte-identical** — those inputs were filtered either way.

This also fixes a **pre-existing** flake (unrelated to the parser change): the live discovery test never set `deadline=None`, so complex RFC 9051 IMAP inputs that occasionally parse in >200 ms tripped Hypothesis's per-example deadline (surfacing as `FlakyFailure`). Now disabled; the full live suite runs green repeatedly.

## Docs

`Rule.parse_all`'s docstring now records the depth limit (pure-Python backend reports it as `ParseError`; Rust is unaffected) and a copy-paste recipe for users who genuinely need to parse very deep input: run the parse on a worker thread with a larger `threading.stack_size` and a raised `sys.setrecursionlimit` (both levers are required — verified against 2000-deep nesting). This keeps the recursive combinator engine as-is; no iterative rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
