### PR TITLE
Add Diátaxis documentation site (Sphinx + MyST + autodoc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 pypi-notes
 profile_rule.py
 .claude
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    # setuptools_scm derives the version from git tags; Read the Docs does a
+    # shallow clone, so fetch history/tags to get the real version.
+    post_checkout:
+      - git fetch --unshallow --tags || true
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs build configuration.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -4,474 +4,80 @@
 ![abnf-tox](https://github.com/declaresub/abnf/workflows/abnf-tox/badge.svg)
 [![CodeQL](https://github.com/declaresub/abnf/actions/workflows/codeql-analysis.yml/badge.svg?branch=master)](https://github.com/declaresub/abnf/actions/workflows/codeql-analysis.yml)
 
-
-ABNF is a package that generates parsers from ABNF grammars as described in [RFC 5234](https://tools.ietf.org/html/rfc5234)
-and [RFC7405](https://tools.ietf.org/html/rfc7405).  The main purpose of this
-package is to parse data as specified in RFCs.  But it should be able to handle any ABNF 
-grammar.
-
-ABNF was originally written a few years ago for parsing HTTP headers in a web framework.
-The code herein has been in use in production here and there on the internet since then.
-
-
-## Requirements
-
-ABNF is tested with Python 3.10-14.
-
+ABNF generates parsers from ABNF grammars as described in
+[RFC 5234](https://tools.ietf.org/html/rfc5234) and
+[RFC 7405](https://tools.ietf.org/html/rfc7405). Its main purpose is parsing data
+specified in RFCs — HTTP headers, email addresses, URIs, and the like — but it
+handles any ABNF grammar. It ships with 30+ ready-to-use grammar modules for common
+RFCs and has been in production use since it was first written for parsing HTTP
+headers in a web framework.
 
 ## Installation
 
-The abnf package is available from [PyPI](https://pypi.org/project/abnf/). As of version 2.3.1, abnf uses
-trusted publishing.
+```console
+pip install abnf
+pip install 'abnf[rust]'   # optional Rust backend, for substantially faster parsing
+```
 
-Install it with the Python installer of your choice:
+ABNF is tested with Python 3.10–3.14.
 
-    pip install abnf
-    uv pip install abnf            # uv
-    uv add abnf                    # uv, inside a project
-    poetry add abnf                # poetry
+## Quick start
 
-For substantially faster parsing, install the optional Rust backend with the `rust` extra:
+```python
+from abnf.grammars import rfc7232
 
-    pip install 'abnf[rust]'
-    uv pip install 'abnf[rust]'
-    uv add 'abnf[rust]'
-    poetry add 'abnf[rust]'
+# parse an ETag header value
+node, offset = rfc7232.Rule("ETag").parse('W/"moof"', 0)
+print(node.value)          # 'W/"moof"'
 
-(Most shells require the quotes around `abnf[rust]` because `[...]` is a glob pattern.)
-See [The Rust backend](#the-rust-backend) for details and benchmark numbers.
+# validate a whole string against a rule (raises ParseError otherwise)
+from abnf.grammars import rfc5322
+rfc5322.Rule("address").parse_all("test@example.com")
 
+# compile your own rule; the RFC 5234 core rules are always available
+from abnf import Rule
+greeting = Rule.create('greeting = "hello" SP 1*ALPHA')
+greeting.parse_all("hello world")
+```
 
-## The Rust backend
+## Documentation
 
-When the `abnf-rust` companion is installed (via `pip install abnf[rust]`), `abnf.parser`
-transparently dispatches its combinator primitives to a Rust extension built with PyO3.
-The public API is unchanged in either case, including every RFC grammar module and every
-example in this README; set the environment variable `ABNF_NO_RUST=1` to force the
-pure-Python backend at runtime.
+Full documentation follows the [Diátaxis](https://diataxis.fr/) framework:
 
-Representative benchmarks (median of three runs of `pytest tests/benchmarks/`, Apple Silicon):
+- **Tutorial** — *Parse your first header*, a ten-minute end-to-end walkthrough.
+- **How-to guides** — validate input, extract values with visitors, load a grammar
+  from a file, write your own grammar module, use the Rust backend.
+- **Reference** — the public API, the built-in core rules, the bundled grammars, and
+  configuration knobs.
+- **Explanation** — the combinator architecture, the two backends, alternation
+  semantics, and how backtracking is kept in check.
 
-| Grammar / input | Pure Python | Rust | Speed-up |
-|---|---|---|---|
-| RFC 3986 URI&nbsp;&nbsp; `https://user:pass@example.com:8080/a/b/c?q=1&r=2#frag` | 190 µs | 28.4 µs | **6.7×** |
-| RFC 5322 mailbox&nbsp;&nbsp; `Charles Yeomans <charles@example.com>` | 422 µs | 44.9 µs | **9.4×** |
-| RFC 7230 request-line&nbsp;&nbsp; `GET /index.html HTTP/1.1\r\n` | 73 µs | 10.4 µs | **7.0×** |
-| RFC 9051 astring&nbsp;&nbsp; `HelloWorld42` | 5.9 µs | 4.0 µs | **1.5×** |
-| Fuzz suite (512 cases, inputs up to 138 KB) | 9.1 s | 1.42 s | **6.4×** |
+To build the docs locally:
 
-### Where the Rust backend helps most
+```console
+pip install -e '.[docs]'
+sphinx-build -W docs docs/_build/html
+```
 
-The Rust backend's biggest advantage is **how cheaply it rejects parses that don't match**.
-ABNF parsing is built around alternation and optional groups: on every backtracking step
-the algorithm tries an alternative, watches it fail, and moves on. The Python combinator's
-failure path raises a `ParseError`, propagates it through generator exception machinery, and
-unwinds Python frames — all comparatively expensive. The Rust equivalent is a single
-`Err(...)` return value with no string formatting. Grammars that exercise this path heavily
-— RFC 5322's deeply-nested `FWS` and `CFWS` whitespace handling is the classic example —
-see the biggest wins.
-
-The advantage compounds with the number of candidate parses the algorithm considers at each
-step. RFC 3986's URI grammar enumerates dozens of partial-parse candidates (optional
-`[ "?" query ]`, optional `[ "#" fragment ]`, multiple `hier-part` alternatives); each
-candidate that ends up losing costs only a few hundred nanoseconds in Rust.
-
-### Where the gap narrows
-
-The Rust backend is *less* dominant on tight grammars whose work is mostly *successful*
-tree-building rather than backtracking. The clearest example among our benchmarks is the
-RFC 9051 `astring` row above: parsing `"HelloWorld42"` against
-
-    astring = 1*ASTRING-CHAR / string
-
-is essentially twelve successful `ASTRING-CHAR` matches plus a single near-instant failure
-on the `string` arm. Each successful match builds a small parse-tree node, and CPython
-optimises that build path extremely well: a small list allocation goes through CPython's
-`list` freelist and costs only a handful of nanoseconds. The Rust equivalent allocates an
-`Arc<Vec<NodeKind>>` per node and crosses the PyO3 boundary — both fast, but still a few
-times more expensive than CPython's open-coded path. The Rust backend still wins on
-`astring`, but only modestly.
-
-Roughly:
-
-| Grammar shape | Typical Rust speed-up |
-|---|---|
-| Heavy alternation / optional / deep backtracking | 6–10× |
-| Mixed: moderate alternation with tree-building | 3–6× |
-| Pure linear success with few alternatives | 1.5–2× |
-
-In other words: the more an ABNF grammar exercises backtracking — which most real RFC
-grammars do — the bigger the win. We have not observed a grammar on which the Rust backend
-is slower than the pure-Python implementation.
-
-### When to skip the Rust backend
-
-For most workloads, `pip install abnf[rust]` is the right choice and is fully transparent
-after install. The pure-Python implementation remains a complete and supported parser, and
-is the right choice when:
-
-* The deployment target rejects compiled extensions (e.g. zip-deployed AWS Lambda layers,
-  some constrained container images).
-* You want to debug or step through parser internals — the pure-Python code is shorter,
-  generator-based, and trivially traceable.
-* `ABNF_NO_RUST=1` is convenient for an A/B comparison.
-
-Much of the optimisation work motivated by the Rust port (lazy `Rule.lparse`, sorted
-`Alternation`, `Match` hash caching, dedup-by-end-position in `Repetition`) also landed in
-the pure-Python implementation, so even without the `[rust]` extra `abnf` parses
-meaningfully faster than its historical baseline.
-
-
-## Usage
-
-The main class of abnf is Rule.  You should think of a Rule subclass as corresponding to an
-ABNF grammar.  Then instances of that subclass represent the rules of that grammar.
-
-The Rule class is initialized with the core ABNF rules OCTET, BIT, HEXDIG, CTL, HTAB, LWSP, 
-CR, VCHAR, DIGIT, WSP, DQUOTE, LF, SP, CRLF, CHAR, ALPHA, and so are available in any subclass
-of Rule.
-
-Create a Rule object using the class method create.
-
-    rule = Rule.create('double-quoted-string = DQUOTE *(%x20-21 / %x23-7E / %x22.22) DQUOTE')
-
-To later retrieve the object just created:
-
-    rule = Rule('double-quoted-string')
-
-Rule objects are cached, so `Rule('double-quoted-string')` should always return the same object,
-though you might not want to depend on that.
-
-ABNF includes several grammars.  The Rule subclass ABNFGrammarRule implements the rules 
-for ABNF.  The package `abnf.grammars` includes grammars from several RFCs.
-
-    from abnf.grammars import rfc7232
-    src = 'W/"moof"'
-    node, start = rfc7232.Rule('ETag').parse(src)
-    print(str(node))
-    
-The output is
-
-    Node(
-        name=ETag, 
-        children=
-            [
-            Node(
-                name=entity-tag, 
-                children=
-                    [
-                    Node(
-                        name=weak, 
-                        children=
-                            [
-                            Node(
-                                name=literal, 
-                                offset=0, 
-                                value="W/"
-                                )
-                            ]
-                        ), 
-                        Node(
-                            name=opaque-tag, 
-                            children=
-                                [
-                                Node(
-                                    name=DQUOTE, 
-                                    children=
-                                        [
-                                        Node(
-                                            name=literal, 
-                                            offset=2, 
-                                            value="""
-                                            )
-                                        ]
-                                    ), 
-                                Node(
-                                    name=etagc, 
-                                    children=
-                                        [
-                                        Node(
-                                            name=literal, 
-                                            offset=3, 
-                                            value="m"
-                                            )
-                                        ]
-                                    ), 
-                                Node(
-                                    name=etagc, 
-                                    children=
-                                        [
-                                        Node(
-                                            name=literal, 
-                                            offset=4, 
-                                            value="o"
-                                            )
-                                        ]
-                                    ), 
-                                Node(
-                                    name=etagc, 
-                                    children=
-                                        [
-                                        Node(
-                                            name=literal, 
-                                            offset=5, 
-                                            value="o"
-                                            )
-                                        ]
-                                    ), 
-                                Node(
-                                    name=etagc, 
-                                    children=
-                                    [
-                                    Node(
-                                        name=literal, 
-                                        offset=6, 
-                                        value="f"
-                                        )
-                                    ]
-                                ), 
-                            Node(
-                                name=DQUOTE, 
-                                children=
-                                    [
-                                    Node(
-                                        name=literal, 
-                                        offset=7, 
-                                        value="""
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    ]
-                )
-            ]
-        )'
-    
-    
-
-
-The modules in `abnf.grammars` may serve as an example for writing other Rule subclasses. 
-In particular, some of the RFC grammars incorporate rules by reference from other RFC. 
-`abnf.grammars.rfc7230` shows a way to import rules from another Rule subclass.
-
-You can also load a grammar from a text file using Rule.from_file.  This class function
-accepts either a str or pathlib.Path. The text file must contain an ABNF rulelist.
-
-
-    class FromFileRule(Rule):
-        pass
-        
-    FromFileRule.from_file('/path/to/grammar.abnf')
-
-
-ABNF uses CRLF as a delimiter for rules in a rulelist.  Beware that many text editors (e.g. BBEdit) 
-substitute line endings without telling the user.
-
-### Errors
-
-abnf implements two exception subclasses, ParseError and GrammarError.  
-
-A GrammarError is raised when parsing encounters an undefined rule, or a prose-value in
-a grammar.  
-
-A ParseError is raised when parsing fails for some reason.  Error reporting is nothing
-more than a stack trace, but that usually allows one to get to the source of the problem.
-
-
-## Examples
-
-### Validate an email address
-
-The code below validates an arbitrary email address.  If src is not syntactically valid,
-a ParseError is raised.
-
-    from abnf.grammars import rfc5322
-    
-    src = 'test@example.com'
-    parser = rfc5322.Rule('address')
-    parser.parse_all(src)
-
-### Extract the actual address from an email address
-
-    from abnf.grammars import rfc5322
-
-    def get_address(node):
-        """Do a breadth-first search of the tree for addr-spec node.  If found, 
-        return its value."""
-        queue = [node]
-        while queue:
-            n, queue = queue[0], queue[1:]
-            if n.name == 'addr-spec':
-                return n.value
-            else:
-                queue.extend(n.children)
-        return None
-
-    src = 'John Doe <jdoe@example.com>'
-    parser = rfc5322.Rule('address')
-    node = parser.parse_all(src)
-    address = get_address(node)
-    
-        
-    for x in node_iterator(node):
-        if x.name == 'addr-spec':
-            print(x.value)
-            break
-
-
-### Extract authentication information from an HTTP Authorization header.
-
-    from abnf.parser import NodeVisitor
-    from abnf.grammars import rfc7235
-
-    header_value = 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'
-    parser = rfc7235.Rule('Authorization')
-    node, offset = parser.parse(header_value, 0)
-
-    class AuthVisitor(NodeVisitor):
-        def __init__(self):
-            super().__init__()
-            self.auth_scheme = None
-            self.token = None
-
-        def visit_authorization(self, node):
-            for child_node in node.children:
-                self.visit(child_node)
-
-        def visit_credentials(self, node):
-            for child_node in node.children:
-                self.visit(child_node)
-
-        def visit_auth_scheme(self, node):
-            self.auth_scheme = node.value
-
-        def visit_token68(self, node):
-            self.token = node.value
-
-    visitor = AuthVisitor()
-    visitor.visit(node)
-    
-The result is that visitor.auth_scheme = 'Basic', and visitor.token = 'YWxhZGRpbjpvcGVuc2VzYW1l'
-
-## Implementation
-
-abnf is implemented using parser combinators. There is a class Literal whose instances are
-initialized with either a string like 'moof', or a tuple like ('a', 'z') representing a range.
-The result is a parser that can match the initialized value.
-
-ABNF operations -- alternation, concatenation, repeat, etc. are implemented as classes.  
-For example, Alternation(Literal('foo'), Literal('bar')) returns a parser that implements the
-ABNF expression 
-
-    "foo" / "bar"
-
-The parser bootstraps itself: the RFC 5234 core rules and the ABNF meta-grammar are
-constructed directly from these combinator classes in code, with no parser available yet
-to read them from text. `ABNFGrammarRule` holds the resulting meta-grammar — it is the
-parser used to read every other grammar, and it can parse its own ABNF source as a
-self-check.
-
-### Backends
-
-abnf has two interchangeable parser implementations behind the same public API:
-
-* **Pure Python** (`abnf._parser_python`) — the default. Always available, depends only on
-  the standard library, and serves as the executable reference for the combinator
-  semantics.
-* **Rust** (`abnf_rust._ext`, installed via `pip install abnf[rust]`) — a PyO3 extension
-  that reimplements the combinator engine and the ABNF meta-grammar in Rust. When
-  importable, `abnf.parser` rebinds its combinator primitives (`Alternation`,
-  `Concatenation`, `Repetition`, `Option`, `Literal`, `Prose`, `Repeat`, `Match`, `Node`,
-  `LiteralNode`) to the Rust pyclasses. `Rule`, `NodeVisitor`, `ParseError`, and
-  `GrammarError` remain Python in either case so that subclassing, the per-class rule
-  registry, and reflective visitor dispatch continue to work unchanged. See
-  [The Rust backend](#the-rust-backend) above for benchmark numbers and the kinds of
-  grammars each implementation handles best.
-
-The dispatch happens once at import time in `abnf.parser`, based on whether the
-companion `abnf_rust` extension is importable. Set `ABNF_NO_RUST=1` in the environment
-to force the pure-Python backend even when the extension is installed.
-
-### Alternation
-
-RFC 5234 does not specify the precise behavior of alternation.  The ABNF definition of 
-ABNF appears to assume longest match.  But other grammars expect first match alternation 
-(e.g. [dhall](https://dhall-lang.org)).  So this behavior is configurable. A class attribute Rule.first_match_alternation
-allows one to choose a behavior for a particular grammar (as represented by a Rule subclass).
-When first_match_alternation is False, alternation returns the longest match; in the event of a tie, 
-the first match is returned. When first_match_alternation is True, the first match is 
-returned.
-
-
-### Backtracking
-
-ABNF implements backtracking as of version 2.0.0.  There were sufficient changes in behavior that this constituted a breaking change, 
-and so the major version has been bumped.
-
-As is well-known, naive implementations of backtracking typically have exponential worst-case behavior.  Here I attempt to reduce that 
-through the use of generators and some caching. In particular, Repetition objects cache parse results.
-
-Version 2.0.0 uses a LRU cache, ParseCache.  The code comes wihout any max sizes set for caches, which will obviously result in long-term issues.  
-My hope is to get feedback from parser usage.  ParseCache has a class attribute max_cache_size: int | None that if set to a non-negative integer, will 
-limit cache size.
-
-        
-## Development, Testing, etc.
-
-To set up a development environment, install in editable mode with the `dev` extra.  Pick whichever installer you prefer:
-
-    pip install -e '.[dev]'
-
-or, with [uv](https://docs.astral.sh/uv/) (which the project's lockfile and CI both use):
-
-    uv sync --extra dev
-
-A good starting point is to run pytest and see that all tests pass:
-
-    pytest --cov-report term-missing --cov=abnf
-
-The test suite includes fuzz testing with test data generated using [abnfgen](http://www.quut.com/abnfgen/).
-Some of the test rules are long and gruesome, so the tests take a bit of time to complete.
-Skip the fuzz tests with:
-
-    pytest --cov-report term-missing --cov=abnf --ignore=tests/fuzz
-
-### Code quality
-
-Pre-commit hooks run ruff, pyright, check-manifest, and tox automatically.  Install them once:
-
-    pre-commit install
-
-To invoke the checks manually:
-
-    ruff check src/abnf       # Lint
-    pyright                   # Type-check
-    tox                       # Run pytest across python 3.10-3.14
-
-### Working with the Rust backend
-
-To build and install the Rust extension against your dev venv:
-
-    pip install -e ./packages/abnf-rust
-
-or, with uv:
-
-    uv pip install -e ./packages/abnf-rust
-
-This drives [maturin](https://www.maturin.rs/) (declared as the PEP 517 build backend) to compile and install the extension; subsequent runs rebuild only what changed.  To force the pure-Python backend even with `abnf-rust` installed:
-
-    ABNF_NO_RUST=1 pytest
-
-To run the Rust crate's own unit tests:
-
-    cargo test --manifest-path packages/abnf-rust/Cargo.toml
-
-
-
-## Third-Party Packages
-
-
-### [abnf-to-regexp](https://pypi.org/project/abnf-to-regexp/1.0.0/)
-
-The program abnf-to-regexp converts augmented Backus-Naur form (ABNF) to a regular expression.
+## Contributing
+
+Set up a development environment with the `dev` extra:
+
+```console
+pip install -e '.[dev]'          # or: uv sync --extra dev
+```
+
+Run the test suite (skip the slower fuzz tests with `--ignore=tests/fuzz`):
+
+```console
+pytest --cov-report term-missing --cov=abnf
+```
+
+Pre-commit hooks run ruff, pyright, check-manifest, and tox. Install them once with
+`pre-commit install`. See the *Explanation* and *How-to* docs for working with the
+Rust backend.
+
+## Third-party packages
+
+- [abnf-to-regexp](https://pypi.org/project/abnf-to-regexp/) — converts ABNF to a
+  regular expression.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,67 @@
+"""Sphinx configuration for the abnf documentation.
+
+Prose (tutorial / how-to / explanation) is authored in Markdown via MyST; the
+API reference is generated from the package's docstrings with autodoc.
+"""
+
+import os
+from importlib.metadata import version as _version
+
+# Document the pure-Python backend: the classes autodoc renders (Rule, Node,
+# NodeVisitor, the exceptions) are always the pure-Python ones regardless of
+# backend, and forcing it keeps the build independent of whether the optional
+# abnf_rust extension happens to be installed in the build environment.
+os.environ.setdefault("ABNF_NO_RUST", "1")
+
+project = "abnf"
+author = "Charles Yeomans"
+copyright = "Charles Yeomans"  # noqa: A001
+
+# The full version, including alpha/beta/rc tags.
+release = _version("abnf")
+# The short X.Y version.
+version = ".".join(release.split(".")[:2])
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "myst_parser",
+    "sphinx_copybutton",
+]
+
+# MyST (Markdown) options.
+myst_enable_extensions = [
+    "colon_fence",  # ::: fenced directives, incl. admonitions
+    "deflist",
+    "smartquotes",
+]
+myst_heading_anchors = 3  # auto-generate anchors for h1..h3
+
+source_suffix = {
+    ".md": "markdown",
+    ".rst": "restructuredtext",
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Autodoc ---------------------------------------------------------------
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+}
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+# -- HTML output -----------------------------------------------------------
+
+html_theme = "furo"
+html_static_path = ["_static"]
+html_title = f"abnf {version}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,8 @@ API reference is generated from the package's docstrings with autodoc.
 """
 
 import os
-from importlib.metadata import version as _version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 # Document the pure-Python backend: the classes autodoc renders (Rule, Node,
 # NodeVisitor, the exceptions) are always the pure-Python ones regardless of
@@ -15,10 +16,15 @@ os.environ.setdefault("ABNF_NO_RUST", "1")
 
 project = "abnf"
 author = "Charles Yeomans"
-copyright = "Charles Yeomans"  # noqa: A001
+copyright = "Charles Yeomans"
 
-# The full version, including alpha/beta/rc tags.
-release = _version("abnf")
+# The full version, including alpha/beta/rc tags.  Read from the installed
+# package metadata; fall back gracefully if the build environment could not
+# resolve a version (e.g. a shallow clone without tags for setuptools_scm).
+try:
+    release = _pkg_version("abnf")
+except PackageNotFoundError:  # pragma: no cover
+    release = "0.0.0"
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
 
@@ -43,7 +49,6 @@ source_suffix = {
     ".rst": "restructuredtext",
 }
 
-templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Autodoc ---------------------------------------------------------------

--- a/docs/explanation/alternation-semantics.md
+++ b/docs/explanation/alternation-semantics.md
@@ -1,0 +1,33 @@
+# Alternation: longest match vs. first match
+
+RFC 5234 does not specify the precise behavior of alternation. The ABNF definition
+of ABNF appears to assume **longest match**, but other grammars expect **first
+match** — for example, [Dhall](https://dhall-lang.org). abnf therefore makes the
+behavior configurable per grammar.
+
+The class attribute `Rule.first_match_alternation` selects the behavior for a
+particular grammar (represented by a `Rule` subclass):
+
+- **`False`** (default) — alternation returns the **longest** match. In the event
+  of a tie, the **first** match (by declaration order) is returned.
+- **`True`** — the **first** matching alternative is returned.
+
+```python
+from abnf import Rule
+
+class FirstMatchGrammar(Rule):
+    first_match_alternation = True
+```
+
+## Why it matters
+
+Consider `astring = 1*ASTRING-CHAR / string`. Under longest-match semantics, the
+parser must try both arms and compare — it cannot commit to `1*ASTRING-CHAR` until
+it knows `string` would not have matched more. Under first-match semantics, the
+first arm that succeeds is taken immediately, which is cheaper but can change which
+parse tree you get for an ambiguous grammar.
+
+Choosing longest match is what makes abnf faithful to RFC grammars out of the box;
+choosing first match lets you model PEG-like grammars that depend on ordered
+choice. The trade-off in cost is discussed in {doc}`backtracking-and-caching` and
+{doc}`rust-backend-performance`.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,44 @@
+# Architecture: parser combinators
+
+abnf is implemented with **parser combinators**. Primitive parsers are composed
+into complex ones, and the composition mirrors the structure of the grammar.
+
+The base primitive is `Literal`, whose instances are initialized with either a
+string like `'moof'` or a two-element tuple like `('a', 'z')` representing an
+inclusive range. The result is a parser that matches the initialized value.
+
+The ABNF operations — alternation, concatenation, repetition, optional groups —
+are each implemented as a class. For example,
+
+```python
+Alternation(Literal("foo"), Literal("bar"))
+```
+
+returns a parser implementing the ABNF expression `"foo" / "bar"`. `Concatenation`,
+`Repetition`, `Option`, and `Prose` fill out the set. Each combinator exposes an
+`lparse(source, start)` method — a generator that yields the matches it finds at
+`start`. Composing combinators composes their generators, and the parse tree of
+`Node` objects falls out of that composition.
+
+A `Rule` ties a name to a combinator tree and maintains a per-subclass registry of
+named rules, so rules can refer to one another by name (including across grammar
+modules).
+
+## Bootstrapping
+
+The parser bootstraps itself. The RFC 5234 core rules and the ABNF meta-grammar are
+constructed directly from the combinator classes in code — there is no parser yet
+to read them from text. `ABNFGrammarRule` holds the resulting meta-grammar: it is
+the parser used to read *every other* grammar, and it can parse its own ABNF source
+as a self-check.
+
+This is why you can hand `Rule.create` a string of ABNF and get back a working
+parser: `ABNFGrammarRule` parses that ABNF text into a parse tree, and a
+`NodeVisitor` walks the tree to build the corresponding combinator objects.
+
+## Working with parse trees
+
+Parsing yields a tree of `Node` objects (with `LiteralNode` leaves). The usual way
+to extract data is a `NodeVisitor` subclass whose `visit_<rulename>` methods are
+dispatched reflectively as the tree is walked — see
+{doc}`../how-to/extract-values-with-visitors`.

--- a/docs/explanation/backends.md
+++ b/docs/explanation/backends.md
@@ -1,0 +1,35 @@
+# The two backends
+
+abnf has two interchangeable parser implementations behind the same public API:
+
+- **Pure Python** (`abnf._parser_python`) — the default. Always available, depends
+  only on the standard library, and serves as the executable reference for the
+  combinator semantics.
+- **Rust** (`abnf_rust._ext`, installed via `pip install abnf[rust]`) — a PyO3
+  extension that reimplements the combinator engine and the ABNF meta-grammar in
+  Rust.
+
+When the Rust extension is importable, `abnf.parser` rebinds its combinator
+primitives — `Alternation`, `Concatenation`, `Repetition`, `Option`, `Literal`,
+`Prose`, `Repeat`, `Match`, `Node`, `LiteralNode` — to the Rust pyclasses. `Rule`,
+`NodeVisitor`, `ParseError`, and `GrammarError` remain Python in either case, so
+subclassing, the per-class rule registry, and reflective visitor dispatch continue
+to work unchanged.
+
+The public API is identical either way, including every bundled grammar module and
+every example in this documentation.
+
+## Dispatch
+
+The choice is made **once, at import time** in `abnf.parser`, based on whether the
+companion `abnf_rust` extension is importable. Set the environment variable
+`ABNF_NO_RUST=1` to force the pure-Python backend even when the extension is
+installed. Because dispatch happens at import, the variable must be set before
+`abnf` is first imported.
+
+The module attribute `abnf.parser._BACKEND` is `"python"` or `"rust"` and reflects
+the active backend.
+
+For guidance on which to install and how to build the extension for development,
+see {doc}`../how-to/use-the-rust-backend`. For where the Rust backend pays off, see
+{doc}`rust-backend-performance`.

--- a/docs/explanation/backtracking-and-caching.md
+++ b/docs/explanation/backtracking-and-caching.md
@@ -1,0 +1,44 @@
+# Backtracking and caching
+
+abnf implements backtracking as of version 2.0.0. This was a change in behavior
+significant enough to warrant the major version bump.
+
+Backtracking is what lets alternation and optional groups explore alternatives: at
+each step the algorithm tries a candidate, and if a later part of the parse fails,
+it retreats and tries the next candidate. It is also the source of a well-known
+hazard — naive backtracking parsers have **exponential** worst-case running time,
+because the same sub-parse can be attempted over and over along different paths.
+
+abnf keeps this in check two ways.
+
+## Laziness
+
+Each combinator's `lparse` is a **generator** that yields matches on demand.
+Callers that only need the first result — for example `Rule.parse`, which wants the
+single longest match — pull one value and stop, so the losing candidates are never
+materialized. Matches are yielded longest-first and de-duplicated by end position,
+so an ambiguous grammar does not pay to build every candidate parse tree.
+
+## Caching
+
+`Repetition` objects memoize their results: a repeated sub-parse at a given
+`(source, start)` is computed once and reused when backtracking revisits it.
+Failures are cached too (as a `_CachedParseError`), so a sub-parse that cannot
+match at a position is not retried there.
+
+The cache is an LRU, `ParseCache`. By default it is unbounded, which is fine for
+one-shot parses but can grow without limit in a long-lived process that parses many
+distinct inputs. Set `Rule.max_cache_size` to a non-negative integer to bound it
+(see {doc}`../reference/configuration`).
+
+```{note}
+The pure-Python parser is recursive-descent, so extremely deeply-nested input can
+exceed the Python recursion limit. Rather than crashing with `RecursionError`, the
+pure-Python backend reports this as a `ParseError`. If you must parse very deeply
+nested input, `Rule.parse_all` documents a worker-thread recipe with a larger
+stack.
+```
+
+For how much the backtracking cost differs between the two backends — the Rust
+backend's cheap failure path is its single biggest advantage — see
+{doc}`rust-backend-performance`.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,11 @@
+# Explanation
+
+Understanding-oriented discussion of how and why abnf works the way it does.
+These pages are for background reading, not step-by-step instructions.
+
+- {doc}`architecture` — parser combinators and the self-bootstrapping meta-grammar.
+- {doc}`backends` — the pure-Python and Rust implementations behind one API.
+- {doc}`alternation-semantics` — longest match vs. first match, and why it's a choice.
+- {doc}`backtracking-and-caching` — how exponential blow-up is kept in check.
+- {doc}`rust-backend-performance` — where the Rust backend wins big and where the
+  gap narrows.

--- a/docs/explanation/rust-backend-performance.md
+++ b/docs/explanation/rust-backend-performance.md
@@ -1,0 +1,72 @@
+# Rust backend performance
+
+When the `abnf-rust` companion is installed (`pip install abnf[rust]`),
+`abnf.parser` transparently dispatches its combinator primitives to a Rust
+extension built with PyO3. The public API is unchanged; set `ABNF_NO_RUST=1` to
+force the pure-Python backend at runtime. This page explains where the Rust backend
+helps and where the gap narrows — see {doc}`backends` for how dispatch works and
+{doc}`../how-to/use-the-rust-backend` for installing and building it.
+
+Representative benchmarks (median of three runs of `pytest tests/benchmarks/`,
+Apple Silicon):
+
+| Grammar / input | Pure Python | Rust | Speed-up |
+|---|---|---|---|
+| RFC 3986 URI `https://user:pass@example.com:8080/a/b/c?q=1&r=2#frag` | 190 µs | 28.4 µs | **6.7×** |
+| RFC 5322 mailbox `Charles Yeomans <charles@example.com>` | 422 µs | 44.9 µs | **9.4×** |
+| RFC 7230 request-line `GET /index.html HTTP/1.1\r\n` | 73 µs | 10.4 µs | **7.0×** |
+| RFC 9051 astring `HelloWorld42` | 5.9 µs | 4.0 µs | **1.5×** |
+| Fuzz suite (512 cases, inputs up to 138 KB) | 9.1 s | 1.42 s | **6.4×** |
+
+## Where the Rust backend helps most
+
+The Rust backend's biggest advantage is **how cheaply it rejects parses that don't
+match**. ABNF parsing is built around alternation and optional groups: on every
+backtracking step the algorithm tries an alternative, watches it fail, and moves
+on. The Python combinator's failure path raises a `ParseError`, propagates it
+through generator exception machinery, and unwinds Python frames — all comparatively
+expensive. The Rust equivalent is a single `Err(...)` return value with no string
+formatting. Grammars that exercise this path heavily — RFC 5322's deeply-nested
+`FWS` and `CFWS` whitespace handling is the classic example — see the biggest wins.
+
+The advantage compounds with the number of candidate parses considered at each
+step. RFC 3986's URI grammar enumerates dozens of partial-parse candidates (optional
+`[ "?" query ]`, optional `[ "#" fragment ]`, multiple `hier-part` alternatives);
+each losing candidate costs only a few hundred nanoseconds in Rust.
+
+## Where the gap narrows
+
+The Rust backend is *less* dominant on tight grammars whose work is mostly
+*successful* tree-building rather than backtracking. The clearest example is the
+RFC 9051 `astring` row above. Parsing `HelloWorld42` against
+
+```abnf
+astring = 1*ASTRING-CHAR / string
+```
+
+is essentially twelve successful `ASTRING-CHAR` matches plus a single near-instant
+failure on the `string` arm. Each successful match builds a small parse-tree node,
+and CPython optimizes that build path extremely well: a small list allocation goes
+through CPython's `list` freelist and costs only a handful of nanoseconds. The Rust
+equivalent allocates an `Arc<Vec<NodeKind>>` per node and crosses the PyO3 boundary
+— both fast, but still a few times more expensive than CPython's open-coded path.
+The Rust backend still wins on `astring`, but only modestly.
+
+Roughly:
+
+| Grammar shape | Typical Rust speed-up |
+|---|---|
+| Heavy alternation / optional / deep backtracking | 6–10× |
+| Mixed: moderate alternation with tree-building | 3–6× |
+| Pure linear success with few alternatives | 1.5–2× |
+
+In other words: the more an ABNF grammar exercises backtracking — which most real
+RFC grammars do — the bigger the win. We have not observed a grammar on which the
+Rust backend is slower than the pure-Python implementation.
+
+## Even without the extra
+
+Much of the optimization work motivated by the Rust port (lazy `Rule.lparse`,
+sorted `Alternation`, `Match` hash caching, dedup-by-end-position in `Repetition`)
+also landed in the pure-Python implementation, so even without the `[rust]` extra
+abnf parses meaningfully faster than its historical baseline.

--- a/docs/how-to/extract-values-with-visitors.md
+++ b/docs/how-to/extract-values-with-visitors.md
@@ -1,0 +1,72 @@
+# Extract values from a parse tree
+
+Parsing gives you a tree of `Node` objects. There are two common ways to pull data
+out of it: a quick manual traversal, or a `NodeVisitor` for anything structured.
+
+```{note}
+Treat a returned parse tree as read-only. Cache hits can cause trees from repeated
+parses of the same input to share descendant `Node` objects, so mutating one tree
+in place can affect another.
+```
+
+## Quick traversal
+
+For a one-off lookup, walk the tree yourself. A node's `name` is its rule name and
+`value` is the source text it matched:
+
+```python
+from abnf.grammars import rfc5322
+
+def find_value(node, rule_name):
+    """Breadth-first search for the first node with the given rule name."""
+    queue = [node]
+    while queue:
+        n, queue = queue[0], queue[1:]
+        if n.name == rule_name:
+            return n.value
+        queue.extend(n.children)
+    return None
+
+node = rfc5322.Rule("address").parse_all("John Doe <jdoe@example.com>")
+find_value(node, "addr-spec")   # 'jdoe@example.com'
+```
+
+## NodeVisitor
+
+For anything beyond a single lookup, subclass `NodeVisitor`. Define a
+`visit_<rule_name>` method for each rule you care about (hyphens in rule names
+become underscores); dispatch is reflective, and `visit(node)` routes to the right
+method as you walk. This example pulls the scheme and token out of an HTTP
+`Authorization` header:
+
+```python
+from abnf import NodeVisitor
+from abnf.grammars import rfc7235
+
+class AuthVisitor(NodeVisitor):
+    def __init__(self):
+        super().__init__()
+        self.auth_scheme = None
+        self.token = None
+
+    def visit_authorization(self, node):
+        for child in node.children:
+            self.visit(child)
+
+    def visit_credentials(self, node):
+        for child in node.children:
+            self.visit(child)
+
+    def visit_auth_scheme(self, node):
+        self.auth_scheme = node.value
+
+    def visit_token68(self, node):
+        self.token = node.value
+
+node, _ = rfc7235.Rule("Authorization").parse("Basic YWxhZGRpbjpvcGVuc2VzYW1l", 0)
+visitor = AuthVisitor()
+visitor.visit(node)
+
+visitor.auth_scheme   # 'Basic'
+visitor.token         # 'YWxhZGRpbjpvcGVuc2VzYW1l'
+```

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,12 @@
+# How-to guides
+
+Task-oriented recipes. Each one assumes you already know the basics (if not, start
+with the {doc}`../tutorial/parse-your-first-header`) and shows how to accomplish a
+specific goal.
+
+- {doc}`validate-input` — check that a string conforms to a grammar.
+- {doc}`extract-values-with-visitors` — pull data out of a parse tree.
+- {doc}`load-a-grammar-from-a-file` — parse with a grammar kept in a `.abnf` file.
+- {doc}`write-your-own-grammar-module` — define a grammar, including importing rules
+  from another.
+- {doc}`use-the-rust-backend` — install, force, and build the optional Rust backend.

--- a/docs/how-to/load-a-grammar-from-a-file.md
+++ b/docs/how-to/load-a-grammar-from-a-file.md
@@ -1,0 +1,37 @@
+# Load a grammar from a file
+
+To keep a grammar in a separate `.abnf` file, define an empty `Rule` subclass and
+populate it with `from_file`, which accepts a `str` path or a `pathlib.Path`. The
+file must contain an ABNF *rulelist*.
+
+```python
+from abnf import Rule
+
+class MyGrammar(Rule):
+    pass
+
+MyGrammar.from_file("grammar.abnf")
+
+MyGrammar("my-top-rule").parse_all("some input")
+```
+
+Given a `grammar.abnf` like:
+
+```abnf
+greeting = "hello" SP name
+name     = 1*ALPHA
+```
+
+`MyGrammar("greeting").parse_all("hello world")` succeeds. The core rules (`SP`,
+`ALPHA`, …) are available without redefinition — see {doc}`../reference/core-rules`.
+
+```{warning}
+ABNF uses CRLF (`\r\n`) to delimit rules in a rulelist. Many text editors silently
+rewrite line endings on save (BBEdit is one), which can quietly break a grammar
+file. `from_file` opens the file expecting CRLF; if you build grammar text in
+memory instead, use `Rule.load_grammar`, which normalizes line endings for you by
+default.
+```
+
+To load grammar text you already have in a string, use `Rule.create` (one rule) or
+`Rule.load_grammar` (a rulelist) — see {doc}`write-your-own-grammar-module`.

--- a/docs/how-to/use-the-rust-backend.md
+++ b/docs/how-to/use-the-rust-backend.md
@@ -1,0 +1,66 @@
+# Use the Rust backend
+
+The optional Rust backend parses substantially faster (typically 6–10× on
+backtracking-heavy grammars) while keeping the public API identical. See
+{doc}`../explanation/rust-backend-performance` for benchmark numbers and where the
+speed-up is largest.
+
+## Install it
+
+Install the `rust` extra with whichever installer you use:
+
+```console
+pip install 'abnf[rust]'
+uv pip install 'abnf[rust]'
+uv add 'abnf[rust]'
+poetry add 'abnf[rust]'
+```
+
+(Most shells need the quotes around `abnf[rust]` because `[...]` is a glob
+pattern.) That's all — `abnf.parser` picks up the `abnf_rust` extension
+automatically at import. Nothing in your code changes.
+
+## Force the pure-Python backend
+
+Set `ABNF_NO_RUST=1` before `abnf` is first imported to use the pure-Python
+implementation even when the extension is installed:
+
+```console
+ABNF_NO_RUST=1 python your_script.py
+```
+
+Useful for debugging parser internals, A/B comparison, or reproducing behavior on a
+machine without the extension. You can confirm which backend is active:
+
+```python
+import abnf.parser
+abnf.parser._BACKEND   # 'python' or 'rust'
+```
+
+## When to skip it
+
+The pure-Python implementation is a complete, supported parser and is the right
+choice when:
+
+- the deployment target rejects compiled extensions (e.g. some zip-deployed AWS
+  Lambda layers or constrained container images);
+- you want to step through parser internals — the pure-Python code is shorter,
+  generator-based, and trivially traceable;
+- `ABNF_NO_RUST=1` is convenient for a comparison.
+
+## Build it for development
+
+To build and install the extension against your dev virtualenv (driving
+[maturin](https://www.maturin.rs/), the declared PEP 517 backend):
+
+```console
+pip install -e ./packages/abnf-rust
+uv pip install -e ./packages/abnf-rust
+```
+
+Subsequent runs rebuild only what changed. Force the pure-Python backend in the test
+suite with `ABNF_NO_RUST=1 pytest`, and run the Rust crate's own tests with:
+
+```console
+cargo test --manifest-path packages/abnf-rust/Cargo.toml
+```

--- a/docs/how-to/validate-input.md
+++ b/docs/how-to/validate-input.md
@@ -1,0 +1,38 @@
+# Validate input against a grammar
+
+To check that a whole string conforms to a rule, use `parse_all`: it parses from the
+start and raises `ParseError` unless the entire input is consumed.
+
+```python
+from abnf.grammars import rfc5322
+from abnf import ParseError
+
+def is_valid_email(src: str) -> bool:
+    try:
+        rfc5322.Rule("address").parse_all(src)
+        return True
+    except ParseError:
+        return False
+
+is_valid_email("test@example.com")          # True
+is_valid_email("not an address")            # False
+```
+
+## `parse` vs. `parse_all`
+
+- `parse(source, start)` returns `(node, offset)` and stops at the longest match it
+  finds — it does **not** require consuming the whole string. Use it when the rule is
+  a prefix of a larger input, and inspect the returned `offset`.
+- `parse_all(source)` returns the `node` and raises `ParseError` if any input is left
+  over. Use it for validation, when the entire string must match.
+
+```python
+node, offset = rfc5322.Rule("address").parse("test@example.com and more", 0)
+# offset points just past the address; parse_all would have raised here
+```
+
+```{note}
+A `ParseError` carries the parser and offset at which parsing failed. A
+`GrammarError` (a different exception) means the grammar itself is unusable at that
+point — an undefined rule or a prose-value — not that the input was invalid.
+```

--- a/docs/how-to/write-your-own-grammar-module.md
+++ b/docs/how-to/write-your-own-grammar-module.md
@@ -1,0 +1,81 @@
+# Write your own grammar module
+
+A `Rule` subclass corresponds to a grammar; instances of the subclass are the rules
+of that grammar. There are a few ways to populate one.
+
+## A single rule with `create`
+
+```python
+from abnf import Rule
+
+rule = Rule.create(
+    'double-quoted-string = DQUOTE *(%x20-21 / %x23-7E / %x22.22) DQUOTE'
+)
+```
+
+Retrieve it later by name (rule objects are cached, so this returns the same
+object):
+
+```python
+rule = Rule("double-quoted-string")
+```
+
+## A whole grammar with `load_grammar`
+
+For several rules at once, subclass `Rule` and call `load_grammar` with a rulelist:
+
+```python
+from abnf import Rule
+
+class Postal(Rule):
+    pass
+
+Postal.load_grammar(
+    """
+    address   = name street zip
+    name      = 1*ALPHA
+    street    = 1*(ALPHA / DIGIT / SP)
+    zip       = 5DIGIT
+    """
+)
+```
+
+`load_grammar` normalizes line endings to CRLF by default. Use a subclass (rather
+than the base `Rule`) so your rules live in their own registry and cannot collide
+with another grammar's.
+
+## Importing rules from another module
+
+Real RFC grammars reuse rules from other RFCs. The bundled grammars do this with the
+`@load_grammar_rules([...])` decorator, passing `(name, rule)` pairs to import.
+`abnf.grammars.rfc7240` is a compact example — it pulls `token`, `quoted-string`,
+`OWS`, and `BWS` in from `rfc7230`:
+
+```python
+from typing import ClassVar
+
+from abnf.parser import Rule as _Rule
+from abnf.grammars import rfc7230
+from abnf.grammars.misc import load_grammar_rules
+
+@load_grammar_rules(
+    [
+        ("token", rfc7230.Rule("token")),
+        ("quoted-string", rfc7230.Rule("quoted-string")),
+        ("OWS", rfc7230.Rule("OWS")),
+        ("BWS", rfc7230.Rule("BWS")),
+    ]
+)
+class Rule(_Rule):
+    grammar: ClassVar[list[str] | str] = [
+        'Prefer = "Prefer" ":" OWS preference *( OWS "," OWS preference )',
+        'preference = token [ BWS "=" BWS word ] *( OWS ";" [ OWS parameter ] )',
+        'parameter = token [ BWS "=" BWS word ]',
+        "word = token / quoted-string",
+    ]
+```
+
+The imported rules are stitched into the subclass's registry at class-definition
+time, so `Rule("preference")` can reference `token` and `OWS` as if they were
+defined locally. Browse `abnf.grammars` for more patterns, and see
+{doc}`../reference/bundled-grammars` for the full list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,80 @@
+# abnf
+
+**abnf** generates parsers from [ABNF](https://tools.ietf.org/html/rfc5234) grammars
+(RFC 5234 and RFC 7405). Its main purpose is parsing data specified in RFCs — HTTP
+headers, email addresses, URIs, and the like — but it handles any ABNF grammar. It
+ships with 30+ ready-to-use grammar modules for common RFCs and has been used in
+production since it was first written for parsing HTTP headers in a web framework.
+
+```python
+from abnf.grammars import rfc7232
+
+node, _ = rfc7232.Rule("ETag").parse('W/"moof"', 0)
+```
+
+## Installation
+
+```console
+pip install abnf
+pip install 'abnf[rust]'   # optional Rust backend, for substantially faster parsing
+```
+
+See {doc}`how-to/use-the-rust-backend` for what the `[rust]` extra buys you.
+
+## The documentation
+
+This documentation follows the [Diátaxis](https://diataxis.fr/) framework — four
+kinds of material, each answering a different need:
+
+- **{doc}`Tutorial <tutorial/parse-your-first-header>`** — learning-oriented. Start
+  here if you are new: build a working parser end to end.
+- **{doc}`How-to guides <how-to/index>`** — task-oriented recipes for specific goals:
+  validate input, walk a parse tree, load a grammar from a file, write your own
+  grammar module, use the Rust backend.
+- **{doc}`Reference <reference/index>`** — information-oriented. The public API, the
+  built-in core rules, the bundled grammars, and configuration knobs.
+- **{doc}`Explanation <explanation/index>`** — understanding-oriented discussion: the
+  combinator architecture, the two backends, alternation semantics, and how
+  backtracking is kept in check.
+
+```{toctree}
+:hidden:
+:caption: Tutorial
+
+tutorial/parse-your-first-header
+```
+
+```{toctree}
+:hidden:
+:caption: How-to guides
+
+how-to/index
+how-to/validate-input
+how-to/extract-values-with-visitors
+how-to/load-a-grammar-from-a-file
+how-to/write-your-own-grammar-module
+how-to/use-the-rust-backend
+```
+
+```{toctree}
+:hidden:
+:caption: Reference
+
+reference/index
+reference/api
+reference/core-rules
+reference/bundled-grammars
+reference/configuration
+```
+
+```{toctree}
+:hidden:
+:caption: Explanation
+
+explanation/index
+explanation/architecture
+explanation/backends
+explanation/alternation-semantics
+explanation/backtracking-and-caching
+explanation/rust-backend-performance
+```

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,49 @@
+# API reference
+
+The public API is exported from the top-level `abnf` package:
+
+```python
+from abnf import Rule, Node, LiteralNode, NodeVisitor, ParseError, GrammarError
+```
+
+The parser combinator primitives (`Alternation`, `Concatenation`, `Repetition`,
+`Option`, `Literal`, `Prose`) are internal and not part of the public API; see
+{doc}`../explanation/architecture` for how they fit together.
+
+## Rule
+
+```{eval-rst}
+.. autoclass:: abnf.Rule
+   :members:
+```
+
+## Node
+
+```{eval-rst}
+.. autoclass:: abnf.Node
+   :members:
+```
+
+## LiteralNode
+
+```{eval-rst}
+.. autoclass:: abnf.LiteralNode
+   :members:
+```
+
+## NodeVisitor
+
+```{eval-rst}
+.. autoclass:: abnf.NodeVisitor
+   :members:
+```
+
+## Exceptions
+
+```{eval-rst}
+.. autoexception:: abnf.ParseError
+
+.. autoexception:: abnf.GrammarError
+
+.. autoexception:: abnf.GrammarWarning
+```

--- a/docs/reference/bundled-grammars.md
+++ b/docs/reference/bundled-grammars.md
@@ -1,0 +1,82 @@
+# Bundled grammars
+
+`abnf.grammars` contains a `Rule` subclass for each of the RFCs below. Import the
+module and use its `Rule` to parse:
+
+```python
+from abnf.grammars import rfc5322
+
+rfc5322.Rule("address").parse_all("test@example.com")
+```
+
+Some modules import rules by reference from others (for example, several HTTP
+extensions reuse `token` and `OWS` from RFC 7230); this composition happens
+automatically at import time. See {doc}`../how-to/write-your-own-grammar-module`
+for how it is wired.
+
+## HTTP core
+
+| Module | RFC | Subject |
+|---|---|---|
+| `rfc2616` | 2616 | HTTP/1.1 (obsolete; a few rules are reused by later RFCs) |
+| `rfc7230` | 7230 | HTTP/1.1 message syntax and routing (obsolete → 9110/9112) |
+| `rfc7231` | 7231 | HTTP/1.1 semantics and content (obsolete → 9110) |
+| `rfc7232` | 7232 | HTTP/1.1 conditional requests (obsolete → 9110) |
+| `rfc7233` | 7233 | HTTP/1.1 range requests (obsolete → 9110) |
+| `rfc7234` | 7234 | HTTP/1.1 caching (obsolete → 9111) |
+| `rfc7235` | 7235 | HTTP/1.1 authentication (obsolete → 9110) |
+| `rfc9110` | 9110 | HTTP semantics |
+| `rfc9111` | 9111 | HTTP caching |
+
+## HTTP extension headers
+
+| Module | RFC | Subject |
+|---|---|---|
+| `rfc6265` | 6265 | HTTP state management (cookies) |
+| `rfc6266` | 6266 | `Content-Disposition` header field |
+| `rfc6797` | 6797 | HTTP Strict Transport Security (`Strict-Transport-Security`) |
+| `rfc7239` | 7239 | `Forwarded` HTTP extension |
+| `rfc7240` | 7240 | `Prefer` header field |
+| `rfc7838` | 7838 | HTTP alternative services (`Alt-Svc`) |
+| `rfc8288` | 8288 | Web linking (`Link` header) |
+| `rfc9651` | 9651 | Structured field values for HTTP (obsoletes 8941) |
+
+## Email
+
+| Module | RFC | Subject |
+|---|---|---|
+| `rfc5322` | 5322 | Internet Message Format (email addresses, headers) |
+| `rfc7489` | 7489 | DMARC |
+
+## URIs, IRIs and encoding
+
+| Module | RFC | Subject |
+|---|---|---|
+| `rfc3986` | 3986 | URI generic syntax |
+| `rfc3987` | 3987 | Internationalized Resource Identifiers (IRIs) |
+| `rfc3629` | 3629 | UTF-8 |
+| `rfc5987` | 5987 | encoding for HTTP header parameters (obsolete → 8187) |
+| `rfc8187` | 8187 | character encoding and language for HTTP header parameters |
+
+## Language tags
+
+| Module | RFC | Subject |
+|---|---|---|
+| `rfc4647` | 4647 | matching of language tags |
+| `rfc5646` | 5646 | tags for identifying languages (BCP 47) |
+
+## Dates, ABNF itself, and more
+
+| Module | RFC | Subject |
+|---|---|---|
+| `rfc3339` | 3339 | date and time on the internet (timestamps) |
+| `rfc5234` | 5234 | ABNF itself, plus the core rules (see `ABNFGrammarRule`) |
+| `rfc7405` | 7405 | case-sensitive string support in ABNF |
+| `rfc9051` | 9051 | IMAP4rev2 |
+| `rfc9116` | 9116 | `security.txt` file format |
+
+```{tip}
+The module source is itself the best worked example of writing a grammar —
+`abnf.grammars.rfc7230` in particular shows importing rules from another
+`Rule` subclass.
+```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,43 @@
+# Configuration
+
+The knobs that change parsing behavior.
+
+## `Rule.first_match_alternation`
+
+A class attribute on a `Rule` subclass. Selects how alternation resolves:
+
+- `False` (default) — **longest match** wins; ties are broken by declaration
+  order.
+- `True` — the **first** matching alternative is returned immediately.
+
+```python
+class MyGrammar(Rule):
+    first_match_alternation = True
+```
+
+See {doc}`../explanation/alternation-semantics` for why this is configurable.
+
+## `Rule.max_cache_size`
+
+An `int | None` class attribute bounding the LRU parse cache that amortizes
+backtracking. `None` (the default) leaves the cache unbounded; set a non-negative
+integer to cap it. See {doc}`../explanation/backtracking-and-caching`.
+
+## `ABNF_NO_RUST` (environment variable)
+
+When set (to any value), forces the pure-Python backend even if the optional
+`abnf_rust` extension is installed. Useful for debugging, benchmarking, or A/B
+comparison. The dispatch is decided once, at import time.
+
+```console
+ABNF_NO_RUST=1 python your_script.py
+```
+
+See {doc}`../explanation/backends` and {doc}`../how-to/use-the-rust-backend`.
+
+## Line endings
+
+ABNF uses CRLF (`\r\n`) as the delimiter between rules in a rulelist. When loading
+a grammar from text (`Rule.create`, `Rule.load_grammar`, `Rule.from_file`), input
+is normalized to CRLF by default. Beware that some text editors silently rewrite
+line endings.

--- a/docs/reference/core-rules.md
+++ b/docs/reference/core-rules.md
@@ -1,0 +1,35 @@
+# Core rules
+
+Every `Rule` subclass is initialized with the RFC 5234 **core rules**, so they are
+available by name in any grammar without being redefined:
+
+```python
+from abnf import Rule
+
+Rule("ALPHA")   # already defined in every Rule subclass
+```
+
+| Rule | ABNF definition | Matches |
+|---|---|---|
+| `ALPHA` | `%x41-5A / %x61-7A` | `A`–`Z`, `a`–`z` |
+| `BIT` | `"0" / "1"` | a binary digit |
+| `CHAR` | `%x01-7F` | any 7-bit US-ASCII character except NUL |
+| `CR` | `%x0D` | carriage return |
+| `CRLF` | `CR LF` | Internet standard newline |
+| `CTL` | `%x00-1F / %x7F` | control characters |
+| `DIGIT` | `%x30-39` | `0`–`9` |
+| `DQUOTE` | `%x22` | the double-quote `"` |
+| `HEXDIG` | `DIGIT / "A" / "B" / "C" / "D" / "E" / "F"` | a hexadecimal digit |
+| `HTAB` | `%x09` | horizontal tab |
+| `LF` | `%x0A` | line feed |
+| `LWSP` | `*(WSP / CRLF WSP)` | linear white space (see the RFC 5234 caveat) |
+| `OCTET` | `%x00-FF` | any 8-bit byte |
+| `SP` | `%x20` | a space |
+| `VCHAR` | `%x21-7E` | any visible (printing) character |
+| `WSP` | `SP / HTAB` | a space or horizontal tab |
+
+```{note}
+`HEXDIG` matches the hexadecimal letters case-insensitively, per the ABNF
+convention that literal strings are case-insensitive unless declared otherwise
+(see {doc}`../explanation/architecture` and RFC 7405).
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,12 @@
+# Reference
+
+Information-oriented technical description. Consult these pages when you need to
+look something up, not to learn concepts (see {doc}`../explanation/index` for the
+"why").
+
+- {doc}`api` — the public classes: `Rule`, `Node`, `LiteralNode`, `NodeVisitor`,
+  and the exceptions.
+- {doc}`core-rules` — the RFC 5234 core rules available in every grammar.
+- {doc}`bundled-grammars` — the 30+ RFC grammar modules in `abnf.grammars`.
+- {doc}`configuration` — class attributes and environment variables that change
+  parser behavior.

--- a/docs/tutorial/parse-your-first-header.md
+++ b/docs/tutorial/parse-your-first-header.md
@@ -1,0 +1,141 @@
+# Parse your first header
+
+This tutorial walks you from an empty environment to parsing a real HTTP header,
+inspecting the result, extracting a value from it, and finally writing a tiny
+grammar of your own. It should take about ten minutes. You don't need to know
+anything about ABNF or parser theory — just follow along, and by the end you'll
+have run every core piece of the library.
+
+## 1. Install abnf
+
+In a fresh virtual environment:
+
+```console
+pip install abnf
+```
+
+Check it imported:
+
+```python
+import abnf
+print(abnf.__version__)
+```
+
+## 2. Parse a header with a bundled grammar
+
+abnf ships with grammars for many RFCs. We'll use the one for HTTP conditional
+requests (RFC 7232) to parse an `ETag` header value. Open a Python prompt and run:
+
+```python
+from abnf.grammars import rfc7232
+
+node, offset = rfc7232.Rule("ETag").parse('W/"moof"', 0)
+```
+
+`rfc7232.Rule("ETag")` is the parser for the `ETag` rule. Its `parse` method takes
+the input string and a starting offset, and returns two things: the **parse tree**
+(`node`) and the **offset** just past what it matched. Check that it consumed the
+whole string:
+
+```python
+print(offset)          # 8, the length of 'W/"moof"'
+```
+
+Congratulations — you've parsed your first header.
+
+## 3. Look at the parse tree
+
+The tree records exactly how the input matched the grammar. Every node has a `name`
+(the rule it came from) and a `value` (the text it matched):
+
+```python
+print(node.name)       # 'ETag'
+print(node.value)      # 'W/"moof"'
+```
+
+Nodes have children, mirroring the grammar's structure. The `ETag` rule is defined
+(in RFC 7232) as `entity-tag`, which is an optional `weak` marker followed by an
+`opaque-tag`. You can see that shape by walking the children:
+
+```python
+for child in node.children:
+    print(child.name, "->", repr(child.value))
+```
+
+Print the whole tree if you're curious — `str(node)` renders it in full:
+
+```python
+print(str(node))
+```
+
+## 4. Extract a value
+
+Usually you don't want the whole tree — you want one piece of it. Here's a small
+breadth-first search that finds the first node with a given rule name and returns
+its matched text:
+
+```python
+def find_value(node, rule_name):
+    queue = [node]
+    while queue:
+        n, queue = queue[0], queue[1:]
+        if n.name == rule_name:
+            return n.value
+        queue.extend(n.children)
+    return None
+
+find_value(node, "opaque-tag")     # '"moof"'
+```
+
+For anything more involved than a single lookup, abnf provides `NodeVisitor`, which
+dispatches a `visit_<rule_name>` method per rule as it walks the tree — see
+{doc}`../how-to/extract-values-with-visitors` when you get there.
+
+## 5. Validate input
+
+`parse` stops at the longest match and doesn't care about leftover input. When you
+want to confirm a string matches a rule *completely*, use `parse_all`, which raises
+`ParseError` if anything is left over:
+
+```python
+from abnf import ParseError
+
+rfc7232.Rule("ETag").parse_all('W/"moof"')     # returns the node, no error
+
+try:
+    rfc7232.Rule("ETag").parse_all('W/"moof" trailing junk')
+except ParseError as exc:
+    print("rejected:", exc)
+```
+
+That's the whole validation story: `parse_all` succeeds or it raises.
+
+## 6. Write a tiny grammar
+
+Finally, let's define a grammar instead of using a bundled one. A `Rule` subclass is
+a grammar; `Rule.create` compiles one rule of ABNF into a parser. The core rules
+(`ALPHA`, `DIGIT`, `SP`, …) are always available:
+
+```python
+from abnf import Rule
+
+greeting = Rule.create('greeting = "hello" SP 1*ALPHA')
+
+node = greeting.parse_all("hello world")
+print(node.value)      # 'hello world'
+```
+
+Read that ABNF as: the literal `"hello"`, a space (`SP`), then one or more letters
+(`1*ALPHA`). Try `greeting.parse_all("hello 123")` and watch it raise `ParseError`
+— `123` isn't `1*ALPHA`.
+
+## Where to go next
+
+You've now installed abnf, parsed with a bundled grammar, read a parse tree,
+extracted a value, validated input, and written your own rule. From here:
+
+- **{doc}`../how-to/index`** — task recipes: visitors, loading grammars from files,
+  building multi-rule grammar modules.
+- **{doc}`../reference/index`** — the API, the core rules, and every bundled grammar.
+- **{doc}`../explanation/index`** — how the combinator engine and the two backends
+  actually work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,16 @@ rust = [
     # with a breaking change can't silently come in via the extra.
     'abnf-rust>=2.5,<3',
 ]
+# Documentation toolchain (Sphinx + MyST for Markdown prose + autodoc for the
+# API reference from docstrings).  Kept separate from `dev` so running the test
+# suite does not require the doc stack.  Pinned to versions that support the
+# project's Python floor (3.10); Read the Docs installs `.[docs]`.
+docs = [
+    'sphinx==8.1.3',
+    'myst-parser==4.0.1',
+    'furo==2025.12.19',
+    'sphinx-copybutton==0.5.2',
+]
 
 [tool.check-manifest]
 ignore = [
@@ -71,6 +81,11 @@ ignore = [
     "packages",
     "packages/**",
     "tests/notes",
+    # Documentation sources are built by Read the Docs from the repo, not
+    # shipped in the sdist.
+    "docs",
+    "docs/**",
+    ".readthedocs.yaml",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ name = "abnf"
 readme = "README.md"
 requires-python = ">= 3.10"
 
+[project.urls]
+Homepage = "https://github.com/declaresub/abnf"
+Documentation = "https://abnf.readthedocs.io/"
+Source = "https://github.com/declaresub/abnf"
+Changelog = "https://github.com/declaresub/abnf/blob/master/CHANGELOG.md"
+Issues = "https://github.com/declaresub/abnf/issues"
+
 
 [project.optional-dependencies]
 dev = [

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -556,14 +556,16 @@ class Rule:
 
     def exclude_rule(self, rule: Rule) -> None:
         """
-        Exclude values which match rule.  For example, suppose we have the following
-        grammar.
-        foo = %x66.6f.6f
-        keyword = foo
-        identifier = ALPHA *(ALPHA / DIGIT )
+        Exclude values which match ``rule``.  For example, suppose we have the
+        following grammar::
 
-        We don't want to allow a keyword to be an identifier.  To do this,
-        Rule('identifier').exclude_rule(Rule('keyword'))
+            foo = %x66.6f.6f
+            keyword = foo
+            identifier = ALPHA *(ALPHA / DIGIT )
+
+        We don't want to allow a keyword to be an identifier.  To do this::
+
+            Rule('identifier').exclude_rule(Rule('keyword'))
 
         Then attempting to use "foo" as an identifier would result in a ParseError.
         """


### PR DESCRIPTION
Splits the monolithic 477-line `README.md` into a Sphinx documentation site organized by the [Diátaxis](https://diataxis.fr/) framework, and slims the README to a landing page.

## Why

The README had grown to carry everything at once — install, usage, rich Rust-backend and implementation discussion, examples, and contributor setup — with no clear separation between *learning*, *doing*, *looking up*, and *understanding*. Diátaxis fits well because most of the raw material was already written; it mostly needed sorting, plus the one quadrant the README lacked entirely: a tutorial.

## Structure

```
docs/
  index.md                       # landing + Diátaxis map
  tutorial/parse-your-first-header.md      # NEW
  how-to/                        # validate, visitors, from-file, own grammar, rust backend
  reference/                     # api (autodoc), core-rules, bundled-grammars, configuration
  explanation/                   # architecture, backends, alternation, backtracking, rust perf
```

- **Tutorial** — a guided, ten-minute end-to-end walkthrough: install → parse a bundled grammar → read the tree → extract a value → validate → write your own rule.
- **How-to** — task recipes migrated and cleaned up from the README's examples (one had a stray `node_iterator` reference; the visitor and BFS recipes are now correct and runnable).
- **Reference** — the public API via `autodoc` from the existing docstrings, plus the core rules, a categorized table of all 30+ bundled grammars, and the configuration knobs (`first_match_alternation`, `max_cache_size`, `ABNF_NO_RUST`).
- **Explanation** — the README's strongest material (combinators + bootstrapping, the two backends, longest-vs-first-match, backtracking/caching, and the full Rust-backend performance discussion), each on its own page.

## Tooling

- **Sphinx + MyST-Parser**: prose is authored in Markdown; the API reference is generated from the current (RST-style) docstrings with `autodoc` — no docstring reformatting needed. Theme is `furo`.
- A separate **`docs` optional-dependency extra** (kept out of `dev`, so running tests doesn't pull the doc stack), pinned to versions supporting the project's Python floor (3.10).
- **`.readthedocs.yaml`** installs `.[docs]` and builds with `-W` (warnings are errors).

## Verification

- `sphinx-build -W` builds clean (fixed one malformed RST docstring on `Rule.exclude_rule` — a `*(` was parsed as emphasis and broke autodoc).
- **Every code example in the docs was executed** against the library and passes (tutorial, all how-to recipes, the `from_file` CRLF flow).
- `check-manifest`, `ruff`, `pyright`, and `tox` all pass. Docs are excluded from the sdist (like `tests/notes`/`packages`); `docs/_build/` is gitignored.

## Build locally

```console
pip install -e '.[docs]'
sphinx-build -W docs docs/_build/html
```

Nothing here gates the release — docs aren't shipped in the wheel. The Read the Docs project can be pointed at this branch/repo to host it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
