### PR TITLE
Group dependabot minor/patch bumps to stop uv.lock drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,20 @@ updates:
     # but not yet caught/yanked.
     cooldown:
       default-days: 7
+    # Batch routine dev-tooling bumps into a single PR with one
+    # consistent uv.lock update. Merging many single-dependency PRs in
+    # sequence otherwise drifts the lockfile: each PR is locked against
+    # an older master, so a later "Update branch" merge can drop an
+    # earlier PR's lock entries. Major bumps still come as individual
+    # PRs so they get their own review (all these deps are dev/build
+    # tooling; the published `abnf` package has no runtime dependencies).
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -21,6 +35,13 @@ updates:
       timezone: America/Kentucky/Monticello
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: cargo
     # Rust workspace for the optional `abnf-rust` companion package.
@@ -39,3 +60,10 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Follow-up to the repeated `uv.lock` repairs (#150, #153): fix the root cause in dependabot config.

## Diagnosis

The config already uses `package-ecosystem: uv`, which *does* commit `uv.lock` — so dependabot isn't failing to lock. The drift comes from **volume**: many single-dependency PRs open at once, each locked against an older `master`. Merging them in sequence (especially via the "Update branch" button) lets a later merge drop an earlier PR's lock entries, leaving `pyproject.toml` and `uv.lock` inconsistent — which is exactly the repair #153 had to do for setuptools / setuptools-scm.

## Fix

Add `groups` to each ecosystem so routine **minor/patch** bumps are batched into a **single PR** with **one consistent lock update**:

- `uv` → group `dev-dependencies`
- `github-actions` → group `actions`
- `cargo` → group `cargo`

**Major** bumps still arrive as individual PRs so they keep their own review (all `uv` deps here are dev/build tooling — the published `abnf` package has no runtime dependencies). The cargo `pyo3` minor/major ignore is unchanged.

## Operational note

Even with grouping, when two PRs are open, prefer letting dependabot rebase (comment `@dependabot rebase`) over the "Update branch" merge button — the rebase re-runs the lock, the merge button can strand it.

Validated: YAML parses, three ecosystems each carry a minor+patch group, pyo3 ignore preserved. Config-only; no runtime/CI impact (takes effect on the next dependabot run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
