### PR TITLE
Test the Rust backend on Windows and macOS, and fix the stack overflow it found

### DIFF
--- a/.github/workflows/abnf-tox.yml
+++ b/.github/workflows/abnf-tox.yml
@@ -53,12 +53,37 @@ jobs:
     # `abnf-rust` extension and runs the same suite against the
     # dispatch shim's Rust path.  Both backends must stay parity-
     # equivalent, so any regression on either side fails CI.
-    name: Rust backend / Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    #
+    # Runs on all three platforms we ship wheels for.  Linux covers
+    # the supported Python range; Windows and macOS add one version
+    # each, because what they contribute is a different toolchain
+    # (MSVC link, Mach-O) rather than a different Python minor — a
+    # full OS x version matrix would be 15 jobs to learn almost
+    # nothing extra.  3.10 and 3.14 pick up the ends of the range at
+    # no cost.  Runner labels are pinned to match release.yml, which
+    # avoids `macos-latest` because that label can shift under us.
+    name: Rust backend / ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # Windows runners default to pwsh; bash is present on all
+        # three images, so every step below stays identical.
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # Linux labels are bare version numbers so these job names
+        # stay byte-identical to the required status checks named in
+        # the branch ruleset.  Renaming them silently drops the
+        # requirement.
+        include:
+        - { label: 'Python 3.10', os: ubuntu-latest, python-version: '3.10' }
+        - { label: 'Python 3.11', os: ubuntu-latest, python-version: '3.11' }
+        - { label: 'Python 3.12', os: ubuntu-latest, python-version: '3.12' }
+        - { label: 'Python 3.13', os: ubuntu-latest, python-version: '3.13' }
+        - { label: 'Python 3.14', os: ubuntu-latest, python-version: '3.14' }
+        - { label: 'Windows / Python 3.10', os: windows-latest, python-version: '3.10' }
+        - { label: 'macOS / Python 3.14', os: macos-15, python-version: '3.14' }
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## Unreleased
 
-Nothing yet.
+* The Rust backend no longer crashes the interpreter on deeply nested input.
+  Its recursion guard bounded the number of nested rule levels (1000, to mirror
+  CPython's recursion limit), but the resource that runs out is stack *bytes*:
+  a level costs ~3 KiB, so reaching 1000 needs ~3 MiB of native stack.  Where
+  the stack was smaller the process died of a stack overflow -- no `ParseError`,
+  no `RecursionError`, nothing catchable -- before the level counter came close
+  to firing.  That was every Windows user of `abnf[rust]`, and anyone on any
+  platform parsing on a thread created with a modest `threading.stack_size`.
+
+  The guard now budgets native stack as well as counting levels, so it fires on
+  the resource that actually runs out and behaves identically everywhere.  The
+  ceiling is lower as a result: roughly 180 levels of rule nesting rather than
+  1000 on platforms whose stack could absorb it.  ABNF grammars nest in the
+  single digits in practice; input approaching this bound is pathological, and
+  is now reported as a `ParseError` on both backends.  To parse deeper input,
+  use the pure-Python backend, whose limit can be raised -- see the
+  worker-thread recipe in `Rule.parse_all`.
+  https://github.com/declaresub/abnf/issues/170
+
+* CI runs the Rust backend on Windows and macOS, not just Linux.  The compiled
+  extension was previously built and tested only on Linux even though wheels
+  ship for five targets, which is why the crash above went unnoticed.
+  https://github.com/declaresub/abnf/issues/167
 
 ## 2.6.0
 

--- a/docs/explanation/backtracking-and-caching.md
+++ b/docs/explanation/backtracking-and-caching.md
@@ -32,11 +32,15 @@ distinct inputs. Set `Rule.max_cache_size` to a non-negative integer to bound it
 (see {doc}`../reference/configuration`).
 
 ```{note}
-The pure-Python parser is recursive-descent, so extremely deeply-nested input can
-exceed the Python recursion limit. Rather than crashing with `RecursionError`, the
-pure-Python backend reports this as a `ParseError`. If you must parse very deeply
-nested input, `Rule.parse_all` documents a worker-thread recipe with a larger
-stack.
+Both parsers are recursive-descent, so extremely deeply-nested input eventually
+runs out of room. Rather than crashing, both report it as a `ParseError`: the
+pure-Python backend when it exceeds the Python recursion limit, the Rust backend
+when nested rules exhaust its native-stack budget (about 180 levels — lower than
+the Python backend's, but identical on every platform and every thread).
+
+To parse input nested more deeply than that, use the pure-Python backend, whose
+limit you can raise: force it with `ABNF_NO_RUST=1` and follow the worker-thread
+recipe in `Rule.parse_all`.
 ```
 
 For how much the backtracking cost differs between the two backends — the Rust

--- a/packages/abnf-rust/rust/core/src/rule.rs
+++ b/packages/abnf-rust/rust/core/src/rule.rs
@@ -17,13 +17,75 @@ use crate::parser::{ArcParser, MatchList, ParseResult};
 /// Maximum nested rule-recursion depth.  A left-recursive grammar
 /// (`a = a "x" / "x"`) would otherwise recurse through Rust native
 /// frames until the OS stack is exhausted and SIGSEGV the whole
-/// process.  Python's `Rule.lparse` raises `RecursionError` from
-/// CPython's interpreter-level guard at roughly the same depth;
-/// matching that bound keeps behaviour comparable across backends.
+/// process.
+///
+/// This bound alone is not enough: it counts levels, while the
+/// resource being protected is stack *bytes*.  See `STACK_BUDGET`.
 const MAX_RULE_RECURSION: usize = 1000;
+
+/// Smallest main-thread stack we assume.  Linux and macOS hand the
+/// main thread ~8 MiB; Windows reserves substantially less (the
+/// crash in issue #170 puts it under 3 MiB, and the MSVC default is
+/// 1 MiB).  Worker threads can be smaller still on any platform —
+/// `threading.stack_size()` reproduces the Windows failure on Linux
+/// and macOS exactly.
+const MIN_SUPPORTED_STACK: usize = 1024 * 1024;
+
+/// Native stack a single `parse` may consume through nested rule
+/// recursion.  Half of `MIN_SUPPORTED_STACK`, leaving headroom for
+/// the Python frames above the outermost `lparse` and for the
+/// deepest Rust frame below the check that trips it.
+///
+/// Issue #170: `MAX_RULE_RECURSION` was set to 1000 to mirror
+/// CPython's default recursion limit, on the theory that matching
+/// counts keeps the backends comparable.  It doesn't — a rule level
+/// costs ~2-3 KiB of native stack here, so 1000 levels wants ~3 MiB.
+/// Where the stack is bigger than that the counter fires first and
+/// all is well; where it is smaller the stack is gone before the
+/// counter is anywhere near 1000, and the process dies with no
+/// catchable error at all.  Budgeting bytes makes the guard fire on
+/// the resource that actually runs out, so behaviour is the same on
+/// every platform and on every thread.
+///
+/// The cost is a lower ceiling than a large stack could support
+/// (~170 levels rather than ~1000).  ABNF grammars nest in the
+/// single digits in practice; anything approaching this bound is
+/// pathological input, which is what the guard is for.
+const STACK_BUDGET: usize = MIN_SUPPORTED_STACK / 2;
 
 thread_local! {
     static RULE_RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
+    /// Address of a local in the frame that entered rule recursion,
+    /// i.e. the outermost `NamedRule::lparse` on this thread.  Zero
+    /// when no parse is in flight.  Distance from here to the
+    /// current frame is how much stack the recursion has eaten.
+    static STACK_ANCHOR: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Address of a local in the calling frame, used to measure stack
+/// consumption.  `black_box` forces `probe` into a real stack slot
+/// rather than a register, and `inline(always)` keeps the slot in
+/// the caller's frame instead of one belonging to this function.
+///
+/// Comparing addresses of locals in different frames is not
+/// something the abstract machine promises anything about, but the
+/// arithmetic is on plain `usize` values, so nothing here is UB —
+/// it is an assumption about how stacks work on the targets we
+/// build for, and `abs_diff` keeps it agnostic to growth direction.
+#[inline(always)]
+fn stack_probe() -> usize {
+    let probe = 0u8;
+    core::hint::black_box(&probe) as *const u8 as usize
+}
+
+/// Why `DepthGuard::enter` refused to recurse another level.
+enum Limit {
+    /// Level count hit `MAX_RULE_RECURSION` — the classic
+    /// left-recursion signature, caught before the stack matters.
+    Depth,
+    /// Stack consumption hit `STACK_BUDGET` — deep nesting on a
+    /// stack too small to reach the level count.
+    Stack { consumed: usize, depth: usize },
 }
 
 /// RAII guard that increments the recursion counter on construction
@@ -32,25 +94,52 @@ thread_local! {
 struct DepthGuard;
 
 impl DepthGuard {
-    /// Try to enter a new recursion level.  Returns `None` when the
-    /// depth limit is already reached, in which case the caller must
-    /// short-circuit with a `ParseError` rather than recursing.
-    fn enter() -> Option<Self> {
+    /// Try to enter a new recursion level.  Returns `Err` when
+    /// either bound is reached, in which case the caller must
+    /// short-circuit rather than recursing.
+    ///
+    /// The outermost level records the stack anchor; every level
+    /// below it measures against that anchor.  A parse re-entered
+    /// from Python mid-recursion (a `PyCallbackParser` callback that
+    /// parses again) keeps the outer anchor, which is correct: its
+    /// frames sit on the same stack and count against the same
+    /// budget.
+    fn enter() -> Result<Self, Limit> {
+        let here = stack_probe();
         RULE_RECURSION_DEPTH.with(|d| {
             let cur = d.get();
             if cur >= MAX_RULE_RECURSION {
-                None
-            } else {
-                d.set(cur + 1);
-                Some(Self)
+                return Err(Limit::Depth);
             }
+            if cur == 0 {
+                STACK_ANCHOR.with(|a| a.set(here));
+            } else {
+                let consumed = STACK_ANCHOR.with(|a| a.get()).abs_diff(here);
+                if consumed > STACK_BUDGET {
+                    return Err(Limit::Stack {
+                        consumed,
+                        depth: cur,
+                    });
+                }
+            }
+            d.set(cur + 1);
+            Ok(Self)
         })
     }
 }
 
 impl Drop for DepthGuard {
     fn drop(&mut self) {
-        RULE_RECURSION_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+        RULE_RECURSION_DEPTH.with(|d| {
+            let next = d.get().saturating_sub(1);
+            d.set(next);
+            if next == 0 {
+                // Unwinding from the depth/stack panic drops every
+                // guard on the way out, so this also re-arms the
+                // anchor for the next parse on this thread.
+                STACK_ANCHOR.with(|a| a.set(0));
+            }
+        });
     }
 }
 
@@ -116,12 +205,24 @@ impl NamedRule {
         // catchable `PanicException` on the Python side, so the
         // resulting behaviour matches the pure-Python backend
         // contract (exception, not a silent success or a segfault).
-        let _guard = DepthGuard::enter().unwrap_or_else(|| {
-            panic!(
+        //
+        // Both bounds panic with the same leading phrase because the
+        // PyO3 layer keys on it (`DEPTH_PANIC_TAG`) to convert the
+        // panic into `RecursionError`.  Only the detail differs, so
+        // a traceback says which limit was hit.
+        let _guard = DepthGuard::enter().unwrap_or_else(|limit| match limit {
+            Limit::Depth => panic!(
                 "maximum rule recursion depth exceeded \
                  (likely a left-recursive grammar) in rule '{}'",
                 self.name
-            )
+            ),
+            Limit::Stack { consumed, depth } => panic!(
+                "maximum rule recursion depth exceeded: native stack budget \
+                 of {STACK_BUDGET} bytes exhausted ({consumed} consumed at \
+                 depth {depth}) in rule '{}' -- input is nested too deeply \
+                 for this thread's stack",
+                self.name
+            ),
         });
         let def = self.definition().ok_or_else(|| self.parse_error(start))?;
         let inner = def.lparse(source, start)?;

--- a/packages/abnf-rust/rust/core/tests/recursion.rs
+++ b/packages/abnf-rust/rust/core/tests/recursion.rs
@@ -1,0 +1,119 @@
+//! Regression tests for issue #170: the rule-recursion guard has to
+//! fire before the native stack runs out, not merely before a level
+//! counter does.
+//!
+//! `MAX_RULE_RECURSION` alone counted levels while the resource being
+//! protected was stack bytes.  A rule level costs ~3 KiB of native
+//! stack, so 1000 levels wants ~3 MiB; on a stack smaller than that
+//! the process died with no catchable error, which is exactly what
+//! the guard existed to prevent.  Both tests below assert the guard
+//! panics -- `catch_unwind` proves the process is still alive to
+//! observe it, which a stack overflow would not allow.
+
+use std::panic;
+use std::sync::Arc;
+
+use abnf_core::{Alternation, ArcParser, Concatenation, Literal, NamedRule, OptionParser, Parser};
+
+/// `nested = "(" [ nested ] ")"` -- recursion driven by input depth.
+fn nested_grammar() -> Arc<NamedRule> {
+    let rule = Arc::new(NamedRule::new("nested"));
+    let self_ref: ArcParser = Arc::new(Parser::from(rule.clone()));
+    let inner: ArcParser = OptionParser::new(self_ref).into();
+    let def: ArcParser = Concatenation::new(vec![
+        Literal::string("(", false).into(),
+        inner,
+        Literal::string(")", false).into(),
+    ])
+    .into();
+    rule.set_definition(def);
+    rule
+}
+
+/// `a = a "x" / "x"` -- recursion with no input progress at all.
+fn left_recursive_grammar() -> Arc<NamedRule> {
+    let rule = Arc::new(NamedRule::new("a"));
+    let self_ref: ArcParser = Arc::new(Parser::from(rule.clone()));
+    let left: ArcParser =
+        Concatenation::new(vec![self_ref, Literal::string("x", false).into()]).into();
+    let def: ArcParser = Alternation::new(vec![left, Literal::string("x", false).into()]).into();
+    rule.set_definition(def);
+    rule
+}
+
+/// Run `f` with the panic hook silenced, returning the panic message
+/// if it panicked.  The guard signals through a panic by design (see
+/// `NamedRule::lparse`), so the hook's stderr banner is just noise
+/// here.
+fn panic_message(f: impl FnOnce() + panic::UnwindSafe) -> Option<String> {
+    let previous = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+    let result = panic::catch_unwind(f);
+    panic::set_hook(previous);
+    result.err().map(|payload| {
+        payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&'static str>().map(|s| s.to_string()))
+            .unwrap_or_default()
+    })
+}
+
+#[test]
+fn deep_nesting_panics_instead_of_overflowing_the_stack() {
+    let rule = nested_grammar();
+    let depth = 5_000;
+    let source = format!("{}{}", "(".repeat(depth), ")".repeat(depth));
+
+    let message = panic_message(move || {
+        let _ = rule.lparse(&source, 0);
+    })
+    .expect("deep nesting must trip the guard, not run to completion");
+
+    // The PyO3 layer keys on this phrase to raise `RecursionError`.
+    assert!(
+        message.contains("maximum rule recursion depth exceeded"),
+        "unexpected panic message: {message}"
+    );
+    // Depth 5000 is far past the byte budget but also past the level
+    // count; the byte budget is the one that should fire first, since
+    // it is reached in ~180 levels.
+    assert!(
+        message.contains("native stack budget"),
+        "expected the stack-budget limit, got: {message}"
+    );
+}
+
+#[test]
+fn left_recursion_still_trips_the_level_counter() {
+    let rule = left_recursive_grammar();
+
+    let message = panic_message(move || {
+        let _ = rule.lparse("xxx", 0);
+    })
+    .expect("left recursion must trip the guard");
+
+    assert!(
+        message.contains("maximum rule recursion depth exceeded"),
+        "unexpected panic message: {message}"
+    );
+}
+
+#[test]
+fn the_guard_resets_between_parses() {
+    let rule = nested_grammar();
+    let deep = format!("{}{}", "(".repeat(5_000), ")".repeat(5_000));
+
+    // Blow the budget, unwind, then parse something trivial.  The
+    // depth counter and the stack anchor are both restored by
+    // `DepthGuard::drop` on the way out; if either leaked, this
+    // second parse would fail or panic.
+    let blown = rule.clone();
+    let source = deep.clone();
+    let _ = panic_message(move || {
+        let _ = blown.lparse(&source, 0);
+    });
+
+    let matches = rule.lparse("()", 0).expect("shallow parse after a blown budget");
+    assert_eq!(matches[0].start, 2);
+}

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -662,14 +662,21 @@ class Rule:
             non-terminal in the grammar is not defined or imported.
 
         .. note::
-            The pure-Python backend is recursive-descent, so input nested more
-            deeply than the Python recursion limit permits is reported as a
-            ParseError rather than crashing with RecursionError.  The Rust
-            backend is not subject to this limit.  If you must parse very deeply
-            nested input on the pure-Python backend, run the parse on a worker
-            thread with a larger stack and a raised recursion limit -- both
-            levers are needed, as ``setrecursionlimit`` alone would overflow the
-            C stack::
+            Both backends are recursive-descent and both bound how deeply they
+            will recurse, reporting input nested past the bound as a ParseError
+            rather than crashing.  The pure-Python backend's bound is CPython's
+            recursion limit.  The Rust backend budgets native stack instead,
+            which puts its ceiling near 180 levels of rule nesting -- lower, but
+            the same on every platform and every thread.  (Before that budget
+            existed the Rust backend counted levels only, and on a stack too
+            small for the count -- Windows, or any thread created with a modest
+            ``threading.stack_size`` -- it overflowed and killed the process.)
+
+            To parse input nested more deeply than that, use the pure-Python
+            backend, whose bound you can raise: force it with ``ABNF_NO_RUST=1``
+            and run the parse on a worker thread with a larger stack and a
+            raised recursion limit.  Both levers are needed, as
+            ``setrecursionlimit`` alone would overflow the C stack::
 
                 import sys, threading
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 import textwrap
 from typing import cast
 
@@ -145,6 +146,16 @@ def test_backtracking():
     assert "".join(n.value for n in match.nodes) == src
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32"
+    and __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
+    reason=(
+        "Issue #170: the Rust backend needs ~3 MiB of native stack to reach "
+        "depth 1000, more than Windows reserves, so the process overflows the "
+        "stack before MAX_RULE_RECURSION trips.  Cannot be xfailed -- the "
+        "overflow is fatal and takes pytest down with it."
+    ),
+)
 def test_deeply_nested_input_does_not_leak_recursionerror():
     """Regression for issue #144: deeply-nested input must not escape as an
     uncaught RecursionError.  The recursive-descent pure-Python parser converts

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -692,6 +692,17 @@ def test_m2_empty_literal_matches_inside_source():
     assert match.start == 1  # empty literal advances nothing
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32"
+    and __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
+    reason=(
+        "Issue #170: MAX_RULE_RECURSION never trips on Windows -- the native "
+        "stack is gone first, so the subprocess dies with STATUS_STACK_OVERFLOW "
+        "(0xC00000FD) instead of exiting cleanly with a caught exception.  "
+        "Left recursion is the case that guard exists for."
+    ),
+    strict=True,
+)
 def test_h5_left_recursive_grammar_is_catchable_not_segfault():
     import subprocess
     import sys

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,4 @@
 import pathlib
-import sys
 import textwrap
 from typing import cast
 
@@ -146,20 +145,12 @@ def test_backtracking():
     assert "".join(n.value for n in match.nodes) == src
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32"
-    and __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
-    reason=(
-        "Issue #170: the Rust backend needs ~3 MiB of native stack to reach "
-        "depth 1000, more than Windows reserves, so the process overflows the "
-        "stack before MAX_RULE_RECURSION trips.  Cannot be xfailed -- the "
-        "overflow is fatal and takes pytest down with it."
-    ),
-)
 def test_deeply_nested_input_does_not_leak_recursionerror():
-    """Regression for issue #144: deeply-nested input must not escape as an
-    uncaught RecursionError.  The recursive-descent pure-Python parser converts
-    it to a ParseError (the documented contract); the Rust backend parses it."""
+    """Regression for issues #144 and #170: deeply-nested input must not escape
+    as an uncaught RecursionError, and must not take the process down either.
+    Both backends convert it to ParseError -- the pure-Python one from CPython's
+    recursion limit, the Rust one from its stack budget (which surfaces as
+    RecursionError and is converted by `Rule.parse` on the way out)."""
 
     class DeepGrammar(Rule):
         pass
@@ -176,9 +167,10 @@ def test_deeply_nested_input_does_not_leak_recursionerror():
     # RecursionError is not caught here, so if the fix regresses it propagates
     # and fails the test.
 
-    if __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "python":
-        # nesting well beyond the Python recursion limit must convert cleanly.
-        assert raised_parse_error
+    # Before #170 the Rust backend parsed this successfully on Linux and macOS
+    # and killed the interpreter on Windows.  Neither is right: the depth is
+    # pathological and the answer is the same catchable error everywhere.
+    assert raised_parse_error
 
 
 def test_alternation_first_match():
@@ -692,17 +684,6 @@ def test_m2_empty_literal_matches_inside_source():
     assert match.start == 1  # empty literal advances nothing
 
 
-@pytest.mark.xfail(
-    sys.platform == "win32"
-    and __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
-    reason=(
-        "Issue #170: MAX_RULE_RECURSION never trips on Windows -- the native "
-        "stack is gone first, so the subprocess dies with STATUS_STACK_OVERFLOW "
-        "(0xC00000FD) instead of exiting cleanly with a caught exception.  "
-        "Left recursion is the case that guard exists for."
-    ),
-    strict=True,
-)
 def test_h5_left_recursive_grammar_is_catchable_not_segfault():
     import subprocess
     import sys
@@ -733,6 +714,67 @@ def test_h5_left_recursive_grammar_is_catchable_not_segfault():
     # negative returncode on POSIX (e.g. -11 for SIGSEGV).
     assert result.returncode == 0, (
         f"left-recursive grammar killed the interpreter: "
+        f"returncode={result.returncode}, stderr={result.stderr!r}"
+    )
+    assert result.stdout.startswith("caught:"), (
+        f"expected a caught exception, got: stdout={result.stdout!r}, "
+        f"stderr={result.stderr!r}"
+    )
+
+
+def test_170_deep_nesting_on_a_small_stack_is_catchable_not_fatal():
+    """Regression for issue #170.
+
+    The guard used to bound recursion by counting levels, which only protects
+    a stack big enough for the count: 1000 levels wants ~3 MiB, so on a
+    smaller stack the process died with no catchable error.  Windows found
+    this because it reserves less than Linux and macOS, but the variable that
+    matters is stack size, not platform -- `threading.stack_size` reproduces
+    it anywhere, which is what this test does so the regression is covered on
+    every runner rather than only on Windows.
+
+    Subprocessed because the pre-fix failure mode is a fatal stack overflow,
+    which pytest cannot observe in-process.
+    """
+
+    import subprocess
+    import sys
+
+    script = textwrap.dedent(
+        """
+        import threading
+        from abnf.parser import Rule
+
+        class G(Rule):
+            pass
+
+        G.create('nested = "(" [ nested ] ")"')
+        src = "(" * 1000 + ")" * 1000
+        out = {}
+
+        def run():
+            try:
+                G("nested").parse_all(src)
+            except Exception as exc:
+                out["result"] = f"caught:{type(exc).__name__}"
+            else:
+                out["result"] = "no-exception"
+
+        threading.stack_size(1024 * 1024)
+        thread = threading.Thread(target=run)
+        thread.start()
+        thread.join()
+        print(out.get("result", "thread-died"))
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"deep nesting on a 1 MiB stack killed the interpreter: "
         f"returncode={result.returncode}, stderr={result.stderr!r}"
     )
     assert result.stdout.startswith("caught:"), (


### PR DESCRIPTION
Closes #167. Closes #170.

Two changes that belong together: the CI gap, and the bug that gap was hiding. Stacked so `master` never carries the skip/xfail that existed between them.

## 1. Rust backend CI on Windows and macOS (#167)

| label | runner | Python |
|---|---|---|
| `Windows / Python 3.10` | `windows-latest` | 3.10 |
| `macOS / Python 3.14` | `macos-15` | 3.14 |

The compiled extension was built and tested only on Linux, though wheels ship for five targets. One Python version per new platform: these contribute a toolchain (MSVC link, Mach-O), not a Python minor. I probed all four Windows versions before settling on one — 3.10, 3.11, 3.12 and 3.14 failed identically, so one job holds the line.

Two details worth a look:

**The matrix is an `include` list with an explicit `label`.** The branch ruleset requires `Rust backend / Python 3.10` … `3.14` by exact name. Interpolating the OS into the job name would have renamed all five and silently dropped the requirement — a ruleset naming a context that no longer exists does not fail, it stops gating. Only the two new contexts need adding.

**Job-level `defaults.run.shell: bash`.** Windows defaults to `pwsh`; pinning bash keeps every step byte-identical across the three images. No change on Linux or macOS.

## 2. The bug it found on its first run (#170)

Under the Rust backend, Windows died of a native stack overflow — exit 127, half the suite unrun — where Linux and macOS raised catchably. Two triggers: deep nesting (`nested = "(" [ nested ] ")"`) and left recursion (`a = a "x" / "x"`), the latter being the exact case the guard was written for.

`MAX_RULE_RECURSION = 1000` counted nested rule *levels*, chosen to mirror CPython's recursion limit. But a level costs ~3 KiB of native stack, so 1000 levels wants ~3 MiB. Where the stack is bigger, the counter fires first and all is well. Where it is smaller, the stack is gone long before the counter is anywhere near 1000 — the guard is not mistuned there, it is **unreachable**. Its own doc comment named the crash it was failing to prevent.

Not really a Windows bug: `threading.stack_size` reproduces it on Linux and macOS exactly. The Rust path SIGBUSed at a 2 MiB thread stack, so anything parsing untrusted input on a worker thread was exposed everywhere.

**The fix** budgets native stack alongside the level count. The outermost `lparse` records a stack anchor; each level below measures against it; exceeding half of the smallest stack we assume (1 MiB) trips the same panic path as the depth limit, so PyO3 still converts it to `RecursionError`.

Measured after the change — the ceiling is now identical regardless of stack size, where 2 MiB previously crashed:

| thread stack | before | after |
|---|---|---|
| 8 MiB (main) | parses depth 1000 | raises past 180 |
| 2 MiB | **SIGBUS** | raises past 180 |
| 1 MiB | **SIGBUS** | raises past 180 |

**The trade-off:** the ceiling drops from ~1000 levels to ~180 where the stack could absorb the old bound. ABNF grammars nest in single digits; input near this bound is pathological, which is what the guard is for. Deeper input needs the pure-Python backend, whose limit can be raised — `parse_all`'s worker-thread recipe now says so explicitly, since that recipe cannot lift the Rust ceiling. Docs and CHANGELOG updated accordingly.

**No hot-path cost.** Both bounds are cheap comparisons. The four parse benchmarks are unchanged (largest delta 1%, within noise):

| case | before | after |
|---|---|---|
| rfc3986_uri | 29.83 µs | 29.54 µs |
| rfc5322_mailbox | 46.37 µs | 46.33 µs |
| rfc7230_request_line | 10.88 µs | 10.92 µs |
| rfc9051_astring | 4.08 µs | 4.00 µs |

## Tests

- `rust/core/tests/recursion.rs` — three tests covering both triggers plus guard state surviving an unwind, using `catch_unwind`, which proves the process is alive to observe the panic as a stack overflow would not allow.
- `test_170_deep_nesting_on_a_small_stack_is_catchable_not_fatal` — reproduces the crash off Windows by parsing on a 1 MiB thread, so every runner covers the regression rather than Windows alone. Subprocessed, because the pre-fix failure is fatal.
- The skip and strict xfail added mid-branch are both removed; the deep-nesting test now asserts `ParseError` on both backends instead of exempting Rust.

## After merge

Add to the `default branch protection` ruleset:

- `Rust backend / Windows / Python 3.10`
- `Rust backend / macOS / Python 3.14`

Then #165 (pyo3 0.29.0 → 0.29.2) can be rebased for a real Windows/macOS signal.

Still open: #168, the release-side half — `release.yml` builds wheels without executing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
