### PR TITLE
Smoke-test each release wheel before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,54 @@ jobs:
         args: --release --out dist
         manylinux: ${{ matrix.target.manylinux }}
 
+    # ------------------------------------------------------------
+    # Smoke test.  Until issue #168 this job's only signal was "it
+    # compiled" — no wheel was ever installed, imported, or run
+    # before it went to PyPI.  A wheel that builds but fails to
+    # import, or imports and silently falls back to the pure-Python
+    # backend, would have shipped.  Combined with CI being
+    # Linux-only at the time, the non-Linux wheels were never
+    # executed at any point in the pipeline (that is how the
+    # Windows stack overflow in #170 survived to a release).
+    #
+    # Runs on the same runner that produced the wheel, so the
+    # artifact is exercised on its own target.
+    # ------------------------------------------------------------
+
+    - name: Set up Python for the smoke test
+      # `linux-aarch64` is cross-compiled on an x86_64 runner, so its
+      # wheel cannot execute here.  Excluded deliberately rather than
+      # by omission — that target's only signal remains "it compiled".
+      # QEMU could close the gap; not worth the complexity yet.
+      if: matrix.target.label != 'linux-aarch64'
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      with:
+        # The extension is built against the stable ABI (abi3-py310),
+        # so one wheel serves 3.10+ and testing on the floor version
+        # exercises the oldest interpreter it claims to support.
+        python-version: "3.10"
+
+    - name: Smoke-test the wheel
+      if: matrix.target.label != 'linux-aarch64'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        # The pure-Python distribution supplies Rule / Node / the
+        # dispatch shim; the wheel only supplies the compiled
+        # combinators behind it.
+        python -m pip install .
+        # --no-index: install the artifact just built, never
+        # something resolved off an index.  If the wheel is
+        # unusable on this platform, this is where it fails.
+        python -m pip install --no-index \
+          --find-links packages/abnf-rust/dist abnf-rust
+        # The shim falls back to pure Python silently when the
+        # extension will not import, which would make the test run
+        # below pass while testing nothing.
+        python -c "import abnf.parser; assert abnf.parser._BACKEND == 'rust', abnf.parser._BACKEND; print('backend:', abnf.parser._BACKEND)"
+        pytest --ignore=tests/fuzz --ignore=tests/benchmarks
+
     - name: Upload wheel
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:


### PR DESCRIPTION
Closes #168.

## What was wrong

`build-abnf-rust-wheel` went from `maturin` straight to `upload-artifact`. No wheel was ever installed, imported, or run before reaching TestPyPI and PyPI — the only signal a release build gave was *"it compiled"*. A wheel that builds but fails to import, or that imports and silently falls back to the pure-Python backend, would have shipped.

Combined with CI having been Linux-only until #169, the four non-Linux wheels were never executed at any point in the pipeline. That is how the Windows stack overflow in #170 could have reached a release.

## What this does

Installs the freshly built wheel on the runner that produced it and runs the suite against it, between `Build wheel` and `Upload wheel`:

- `--no-index --find-links packages/abnf-rust/dist` — tests the artifact just built, never something resolved off an index.
- Asserts `_BACKEND == 'rust'` before running anything. The dispatch shim falls back to pure Python silently when the extension will not import, so without this the test run would pass while testing nothing.
- Python 3.10 on the smoke-test interpreter: the extension is `abi3-py310`, so one wheel serves 3.10+ and the floor version is the oldest interpreter it claims to support.

`linux-aarch64` is excluded — cross-compiled on an x86_64 runner, so its wheel cannot execute there. Commented rather than quietly omitted, so the remaining gap stays visible. QEMU could close it; not worth the complexity yet.

## Verification

`release.yml` only fires on `v*` tags, so the step could not otherwise be proven without cutting a release — which is the same "untested until release" problem this PR exists to fix. I ran a temporary push-triggered copy of the job on this branch across all five targets ([run 31430234944](https://github.com/declaresub/abnf/actions/runs/31430234944)):

| target | wheel | smoke test |
|---|---|---|
| linux-x86_64 | built | `backend: rust`, 1362 passed |
| macos-x86_64 | built | `backend: rust`, 1362 passed |
| macos-arm64 | built | `backend: rust`, 1362 passed |
| windows-x86_64 | built | `backend: rust`, 1362 passed |
| linux-aarch64 | built | skipped, as intended |

The probe workflow was deleted before this PR was finalized and is not part of the diff — the branch is a single commit touching only `release.yml`.

Note that this PR's own checks cannot exercise the change: `abnf-tox` runs on pull requests, `release.yml` does not. The run above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
