### PR TITLE
Validate parse start and reject impossible repetition bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+* `Rule.parse` now validates `start` and raises `ValueError` if it falls outside
+  `0 <= start <= len(source)`.  It was previously unchecked, and a negative
+  value is a valid Python slice measured from the end of the source, so the
+  parse quietly succeeded at a position the caller never asked for and returned
+  negative node offsets -- `parse("abcdef", -4)` matched `"cd"`.  The Rust
+  backend raised `OverflowError` on the same call, so the two backends
+  disagreed on a case where neither answer was right.  `start` is also
+  normalised with `operator.index`, so `True` becomes `1` rather than reaching
+  `ParseError.start` verbatim, and a non-integer raises `TypeError` with the
+  same message on both backends.
+
+* A repetition whose maximum is below its minimum now raises `GrammarError`
+  when the grammar is loaded, on both backends.  `3*2"a"` is an impossible
+  range, but it silently behaved as `3*"a"` -- rejecting `"aa"` while accepting
+  `"aaa"`, `"aaaa"` and so on -- so a typo for `2*3` became unbounded
+  repetition with no diagnostic.
+
 * The Rust backend no longer crashes the interpreter on deeply nested input.
   Its recursion guard bounded the number of nested rule levels (1000, to mirror
   CPython's recursion limit), but the resource that runs out is stack *bytes*:

--- a/packages/abnf-rust/rust/pyo3/src/errors.rs
+++ b/packages/abnf-rust/rust/pyo3/src/errors.rs
@@ -38,3 +38,28 @@ fn get_parse_error_class(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
     cls.cast_into::<PyType>()
         .map_err(|e| e.into())
 }
+
+/// Build an `abnf.parser.GrammarError` carrying `message`.
+///
+/// Same reasoning as `parse_error_to_pyerr`: the Python class is the
+/// one users write `except` clauses against, so a malformed grammar
+/// has to raise it whichever backend caught the problem.  Only ever
+/// called on an error path, so the module import costs nothing in
+/// normal operation.
+pub fn grammar_error(py: Python<'_>, message: &str) -> PyErr {
+    let cls = match get_grammar_error_class(py) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    match cls.call1((message,)) {
+        Ok(exc) => PyErr::from_value(exc),
+        Err(e) => e,
+    }
+}
+
+fn get_grammar_error_class(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
+    let module = py.import("abnf.parser")?;
+    let cls = module.getattr("GrammarError")?;
+    cls.cast_into::<PyType>()
+        .map_err(|e| e.into())
+}

--- a/packages/abnf-rust/rust/pyo3/src/parsers.rs
+++ b/packages/abnf-rust/rust/pyo3/src/parsers.rs
@@ -37,8 +37,21 @@ pub struct PyRepeat {
 impl PyRepeat {
     #[new]
     #[pyo3(signature = (min=0, max=None))]
-    fn new(min: usize, max: Option<usize>) -> Self {
-        Self { min, max }
+    fn new(py: Python<'_>, min: usize, max: Option<usize>) -> PyResult<Self> {
+        // Mirrors the check in the pure-Python `Repeat.__init__`:
+        // `3*2` is an impossible range, and leaving it unvalidated
+        // silently behaves as `3*`.  Both backends must reject it
+        // identically, so this raises the same `GrammarError`.
+        if let Some(max) = max {
+            if max < min {
+                let msg = format!(
+                    "Repeat max ({max}) is less than min ({min}); \
+                     a repetition of {min}*{max} can never match."
+                );
+                return Err(crate::errors::grammar_error(py, &msg));
+            }
+        }
+        Ok(Self { min, max })
     }
 
     fn __str__(&self) -> String {

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 import pathlib
 import typing
 import warnings
@@ -258,6 +259,17 @@ class Repeat:
     """Implements the ABNF Repeat operator for Repetition."""
 
     def __init__(self, min: int = 0, max: int | None = None):
+        # `3*2` is an impossible range.  Silently treating it as `3*`
+        # -- which is what an unvalidated max does, since the loop
+        # never reaches an upper bound it has already passed -- turns
+        # a typo for `2*3` into unbounded repetition with no
+        # diagnostic.  Reject it where the grammar is built.
+        if max is not None and max < min:
+            msg = (
+                f"Repeat max ({max}) is less than min ({min}); "
+                f"a repetition of {min}*{max} can never match."
+            )
+            raise GrammarError(msg)
         self.min = min
         self.max = max
 
@@ -622,7 +634,28 @@ class Rule:
         :raises ParseError: if source cannot be parsed using rule.
         :raises GrammarError: if rule has no definition.  This usually means that a
             non-terminal in the grammar is not defined or imported.
+        :raises ValueError: if start is outside ``0 <= start <= len(source)``.
         """
+
+        # Normalise first: this turns `True` into `1` (the Rust
+        # backend already treated it as an index, while here it ended
+        # up verbatim in `ParseError.start`) and rejects non-integers
+        # with the same message the Rust backend produces.
+        start = operator.index(start)
+
+        # Without this check a negative start is a valid Python slice
+        # measured from the end of the source, so the parse quietly
+        # succeeds at a position the caller never asked for and hands
+        # back negative node offsets: `parse("abcdef", -4)` matches
+        # "cd".  The Rust backend raises OverflowError on the same
+        # input, so the backends disagreed on a case where neither
+        # answer was right.
+        if not 0 <= start <= len(source):
+            msg = (
+                f"start must be in 0..{len(source)} for a source of "
+                f"length {len(source)}; got {start}."
+            )
+            raise ValueError(msg)
 
         g = self.lparse(source, start)
         # `lparse` yields matches longest-first (the upstream

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -204,6 +204,100 @@ def test_repetition_str():
     assert str(Repetition(Repeat(1, 2), Literal("foo")))
 
 
+# ---------------------------------------------------------------------------
+# X4: `min*max` with max < min is an impossible range.  Unvalidated it
+# silently behaves as `min*` -- `3*2"a"` rejected "aa" but accepted "aaa",
+# "aaaa", ... -- so a typo for `2*3` became unbounded repetition with no
+# diagnostic.  Both backends must reject it identically.
+# ---------------------------------------------------------------------------
+
+
+def test_x4_repeat_max_less_than_min_raises():
+    with pytest.raises(GrammarError):
+        Repeat(3, 2)
+
+
+def test_x4_repeat_max_equal_to_min_is_fine():
+    # The boundary is legal: `2*2` is an exact count, spelled `2` in ABNF.
+    assert str(Repeat(2, 2))
+
+
+def test_x4_impossible_repetition_rejected_at_grammar_load():
+    class BadRepeatRule(Rule):
+        pass
+
+    with pytest.raises(GrammarError):
+        BadRepeatRule.create('s = 3*2"a"')
+
+
+def test_x4_ordinary_repetition_bounds_still_load():
+    class GoodRepeatRule(Rule):
+        pass
+
+    GoodRepeatRule.create('s = 2*3"a"')
+    assert GoodRepeatRule("s").parse_all("aa")
+    assert GoodRepeatRule("s").parse_all("aaa")
+    with pytest.raises(ParseError):
+        GoodRepeatRule("s").parse_all("aaaa")
+
+
+# ---------------------------------------------------------------------------
+# X2: `start` was never validated.  A negative value is a valid Python slice
+# measured from the end of the source, so `parse("abcdef", -4)` matched "cd"
+# and returned negative node offsets, while the Rust backend raised
+# OverflowError -- the backends disagreed on a case where neither was right.
+# ---------------------------------------------------------------------------
+
+
+class StartRule(Rule):
+    pass
+
+
+StartRule.create('mid = "cd"')
+StartRule.create("one = %x61-7A")
+
+
+@pytest.mark.parametrize("start", [-1, -4, -99])
+def test_x2_negative_start_rejected(start: int):
+    with pytest.raises(ValueError, match="start must be in"):
+        StartRule("mid").parse("abcdef", start)
+
+
+@pytest.mark.parametrize("start", [7, 99])
+def test_x2_start_past_end_rejected(start: int):
+    with pytest.raises(ValueError, match="start must be in"):
+        StartRule("mid").parse("abcdef", start)
+
+
+def test_x2_start_at_end_of_source_is_allowed():
+    # len(source) is a legal position -- there is simply nothing to match
+    # there, which is a ParseError rather than a programming error.
+    with pytest.raises(ParseError):
+        StartRule("mid").parse("abcdef", 6)
+
+
+def test_x2_valid_start_still_parses():
+    node, start = StartRule("mid").parse("abcdef", 2)
+    assert node.value == "cd"
+    assert start == 4
+
+
+def test_x2_bool_start_is_normalised_to_int():
+    # bool is an int subclass, so `True` was used as an index but arrived
+    # verbatim in ParseError.start on the Python backend while the Rust
+    # backend reported 1.  operator.index normalises it.
+    with pytest.raises(ParseError) as excinfo:
+        StartRule("mid").parse("abcdef", True)
+    assert excinfo.value.start == 1
+    assert not isinstance(excinfo.value.start, bool)
+
+
+@pytest.mark.parametrize("start", [1.5, None, "2"])
+def test_x2_non_integer_start_rejected(start: object):
+    with pytest.raises(TypeError, match="cannot be interpreted as an integer"):
+        StartRule("mid").parse("abcdef", start)  # type: ignore[arg-type]
+
+
 def test_option_str():
     assert str(Option(Literal("foo")))
 


### PR DESCRIPTION
Fixes X2 and X4 from the cross-backend audit.

*(Merged 2026-08-12 containing only the X2/X4 commit.  A later commit — documentation and the surrogate error messages — was pushed to this branch after the merge and did not land here; it is #176.  This description has been trimmed to match what was actually merged.)*

---

## 1. `Rule.parse` never validated `start` (X2)

A negative value is a valid Python slice measured from the end of the source, so the parse quietly succeeded at a position the caller never asked for:

```python
G.create('mid = "cd"')
G("mid").parse("abcdef", -4)   # before: matched 'cd', leaf.offset -4, next start -2
                               # after:  ValueError: start must be in 0..6 ... got -4.
```

The Rust backend raised `OverflowError` on the same call — neither answer was right, and they weren't wrong in the same way. Now `0 <= start <= len(source)`, else `ValueError`. `len(source)` stays legal: nothing matches there, which is a `ParseError`, not a programming error.

`start` is also normalised with `operator.index`, converging two smaller divergences found in the same probe:

| call | before (Python) | before (Rust) | after (both) |
|---|---|---|---|
| `parse("abc", -1)` | matched, or `ParseError: ... -1` | `OverflowError` | `ValueError` |
| `parse("abc", 99)` | `ParseError: ... 99` | `ParseError: ... 3` | `ValueError` |
| `parse("abc", True)` | `ParseError: ... True` | `ParseError: ... 1` | `ParseError: ... 1` |
| `parse("abc", 1.5)` | `TypeError: slice indices...` | `TypeError: 'float' object cannot...` | `TypeError: 'float' object cannot...` |

## 2. `min*max` with `max < min` silently ignored `max` (X4)

```
before: 3*2"a" accepts -> 0:no 1:no 2:no 3:ok 4:ok 5:ok 6:ok
after:  GrammarError: Repeat max (2) is less than min (3); a repetition of 3*2 can never match.
```

A typo for `2*3` became unbounded repetition with no diagnostic. Now rejected at load by both `Repeat.__init__` and `PyRepeat::new`; the Rust side grows a small `errors.rs` helper so it raises the *same* `abnf.parser.GrammarError` class rather than a lookalike, following the existing `parse_error_to_pyerr` pattern.

`GrammarError` rather than a warning because `3*2` is syntactically valid ABNF and semantically impossible — the same shape as `s = nonesuch`, which has always raised `GrammarError`. `ParseError` remains the "not valid ABNF" case. `2*2` stays legal.

## Verification

- Both reproducers now behave identically on both backends.
- The API-edge matrix is identical across backends except `Node.__repr__` and `bytes`-source rejection (`TypeError` vs `AttributeError`) — the latter is `source` typing rather than `start`, so out of scope.
- 1200 differential fuzz cases across 15 bundled grammar rules: **zero divergences**.
- Parse benchmarks unchanged: 29.4 / 46.1 / 10.9 / 4.0 µs against a 29.5–29.8 / 46.3 / 10.9 / 4.0 baseline.
- 1377 tests pass on both backends; ruff, pyright, and `cargo clippy --all-targets` clean.

## Note

`ValueError` and `GrammarError` are new failure modes for input that previously "worked" — in each case the old behaviour was a wrong answer (X2) or a silently dropped bound (X4). Regression tests are `test_x2_*` and `test_x4_*` in `tests/test_parser.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

