### PR TITLE
Document the code-point model; explain the surrogate limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+* Document what `abnf` parses: code points, not bytes.  A terminal value in a
+  grammar is a code-point value, a Python `str` is a sequence of code points,
+  and wire data is parsed by decoding it with latin-1, which maps the 256 byte
+  values onto `U+0000`-`U+00FF` one to one so that a code point is exactly an
+  octet.  New "What abnf parses" page, a note on `Rule.parse_all`, and a README
+  section.  This is why there is no bytes API: latin-1 already gives exact octet
+  semantics for one method call.
+  https://github.com/declaresub/abnf/issues/174
+
+* The Rust backend now explains itself when it meets a surrogate code point,
+  which it cannot represent because Rust strings are well-formed UTF-8.  A
+  grammar containing one (`%xD800-DBFF`) raised `TypeError: value argument must
+  be a string or a 2-tuple of strings` -- about a value that *was* a string --
+  and input containing one (from `surrogateescape`, or an unpaired `\uD800` out
+  of `json.loads`) raised a bare `UnicodeEncodeError` that never mentioned
+  `abnf`.  Both now name the surrogate as the cause and point at
+  `ABNF_NO_RUST=1`, which selects the pure-Python backend.  The underlying
+  limitation is unchanged.
+  https://github.com/declaresub/abnf/issues/173
+
 * `Rule.parse` now validates `start` and raises `ValueError` if it falls outside
   `0 <= start <= len(source)`.  It was previously unchecked, and a negative
   value is a valid Python slice measured from the end of the source, so the

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ greeting = Rule.create('greeting = "hello" SP 1*ALPHA')
 greeting.parse_all("hello world")
 ```
 
+## Parsing bytes
+
+`abnf` parses code points, so `parse` and `parse_all` take a `str`. To parse wire
+data, decode it with latin-1 — that maps the 256 byte values onto `U+0000`–`U+00FF`
+one to one, so a code point is exactly an octet and octet-oriented grammars behave
+as their RFCs describe:
+
+```python
+rfc7230.Rule("request-line").parse_all(raw.decode("latin-1"))
+```
+
+See [What abnf parses](https://abnf.readthedocs.io/en/latest/explanation/what-abnf-parses.html)
+for why the encoding is the caller's choice.
+
 ## Documentation
 
 Full documentation is hosted at **[abnf.readthedocs.io](https://abnf.readthedocs.io/en/latest/)**
@@ -51,8 +65,9 @@ and follows the [Diátaxis](https://diataxis.fr/) framework:
   from a file, write your own grammar module, use the Rust backend.
 - **Reference** — the public API, the built-in core rules, the bundled grammars, and
   configuration knobs.
-- **Explanation** — the combinator architecture, the two backends, alternation
-  semantics, and how backtracking is kept in check.
+- **Explanation** — what abnf parses (code points, not bytes), the combinator
+  architecture, the two backends, alternation semantics, and how backtracking is
+  kept in check.
 
 To build the docs locally:
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -3,6 +3,8 @@
 Understanding-oriented discussion of how and why abnf works the way it does.
 These pages are for background reading, not step-by-step instructions.
 
+- {doc}`what-abnf-parses` — code points, not bytes: what a terminal value means
+  and how to parse wire data.
 - {doc}`architecture` — parser combinators and the self-bootstrapping meta-grammar.
 - {doc}`backends` — the pure-Python and Rust implementations behind one API.
 - {doc}`alternation-semantics` — longest match vs. first match, and why it's a choice.

--- a/docs/explanation/what-abnf-parses.md
+++ b/docs/explanation/what-abnf-parses.md
@@ -1,0 +1,87 @@
+# What abnf parses: code points, not bytes
+
+`abnf` parses **sequences of Unicode code points**. A Python `str` is exactly
+that, which is why `parse` and `parse_all` take a `str` and nothing else.
+
+That one sentence answers most of the questions people arrive with, including
+"can it parse bytes?" — see [Parsing wire data](#parsing-wire-data) below, where
+the answer is yes, with a one-line decode.
+
+## Terminal values are code-point values
+
+In ABNF a terminal is written as a numeric value: `%x41` is `A`, `%d97` is `a`,
+`%x61-7A` is the range `a`–`z`. `abnf` reads those as **code-point** values, so
+they mean what the RFC that wrote them meant:
+
+```text
+ALPHA   = %x41-5A / %x61-7A          ; ASCII letters
+ucschar = %xA0-D7FF / %xF900-FDCF / %x10000-1FFFD / ...   ; RFC 3987, IRIs
+```
+
+`%x10000-1FFFD` is a range of astral-plane characters, and matching it against a
+`str` works because a `str` holds code points. There is no encoding step and no
+encoding assumption anywhere in the parse.
+
+## Parsing wire data
+
+Protocol data arrives as bytes, and ABNF grammars for protocols are written in
+octets: `OCTET = %x00-FF`, `obs-text = %x80-FF`. Decode with **latin-1** and one
+code point is exactly one octet:
+
+```python
+from abnf.grammars import rfc7230
+
+raw = b"GET /index.html HTTP/1.1\r\n"          # bytes off the wire
+rfc7230.Rule("request-line").parse_all(raw.decode("latin-1"))
+```
+
+latin-1 maps the 256 byte values onto the 256 code points `U+0000`–`U+00FF`, one
+to one, in both directions. It is total — every byte string decodes, including
+arbitrary binary — and `.encode("latin-1")` returns the original bytes exactly.
+It costs nothing: CPython stores such a string at one byte per code point, so
+the decode is a copy with no change in memory footprint.
+
+```{important}
+Which encoding you decode with is a semantic choice, and `abnf` cannot make it
+for you. Consider two octets of UTF-8:
+
+    raw = b"\xc3\xa9"                        # 'é' encoded as UTF-8
+
+    1*OCTET against raw.decode("latin-1")    -> 2 octets
+    1*OCTET against raw.decode("utf-8")      -> 1 octet
+
+Both are right. The first reads the data as a byte protocol, where `OCTET` means
+octet and there are two of them. The second reads it as text, where there is one
+character. If you are parsing an HTTP header or an email message, you want
+latin-1: those grammars count octets.
+```
+
+## Surrogates
+
+Code points `U+D800`–`U+DFFF` are surrogates. They are legal in a Python `str`
+but have no character meaning, and they arrive in real data — `surrogateescape`
+is how Python represents undecodable bytes in filenames, `sys.argv`, and
+environment variables, and an unpaired `\uD800` survives `json.loads`.
+
+A grammar can name them (`%xD800-DBFF`) and the pure-Python backend will match
+them, but whether they appear at all depends on how *you* decoded: a strict
+`utf-8` or `utf-16` decode rejects them, while `surrogatepass` and
+`surrogateescape` preserve them. That is a property of the decode, not of the
+parser.
+
+```{note}
+The Rust backend cannot represent surrogate code points, because Rust strings
+are well-formed UTF-8. A grammar containing one raises `GrammarError`, and input
+containing one raises `ValueError`; both messages say so and point at
+`ABNF_NO_RUST=1`, which selects the pure-Python backend. Tracked as
+[issue #173](https://github.com/declaresub/abnf/issues/173).
+```
+
+## Why there is no bytes API
+
+A `bytes` entry point would buy no capability — latin-1 already gives exact
+octet semantics — while costing an `encoding` parameter, a second node-value
+type, and a permanent second path through the parser. The decode is one method
+call and stays where the knowledge lives: with the caller who knows what their
+data is. See [issue #25](https://github.com/declaresub/abnf/issues/25) for the
+full reasoning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,7 @@ reference/configuration
 :caption: Explanation
 
 explanation/index
+explanation/what-abnf-parses
 explanation/architecture
 explanation/backends
 explanation/alternation-semantics

--- a/packages/abnf-rust/rust/pyo3/src/parsers.rs
+++ b/packages/abnf-rust/rust/pyo3/src/parsers.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
+use pyo3::types::{PyString, PyTuple};
 
 use abnf_core::{
     arc, Alternation, ArcParser, Concatenation, Literal, LiteralKind, OptionParser, Parser, Prose,
@@ -214,6 +214,37 @@ impl PyOption {
 // Literal
 // ----------------------------------------------------------------
 
+/// If `value` is a `str` — or a tuple containing one — that cannot be
+/// converted to a Rust `String`, return its `repr` for use in a
+/// diagnostic.  The only way a genuine `str` fails to convert is by
+/// containing a surrogate code point, which is well-formed in Python
+/// and unrepresentable in Rust.  Returns `None` when the value simply
+/// is not a string, which is an ordinary type error.
+///
+/// `repr` is used rather than the value itself because it renders
+/// surrogates as escapes and so is safe to interpolate.
+fn unrepresentable_str(value: &Bound<'_, PyAny>) -> Option<String> {
+    fn bad(obj: &Bound<'_, PyAny>) -> Option<String> {
+        if obj.is_instance_of::<PyString>() && obj.extract::<String>().is_err() {
+            return Some(
+                obj.repr()
+                    .map(|r| r.to_string_lossy().into_owned())
+                    .unwrap_or_else(|_| "<unrepresentable>".to_string()),
+            );
+        }
+        None
+    }
+
+    if let Some(r) = bad(value) {
+        return Some(r);
+    }
+    // Range bounds arrive as a 2-tuple, e.g. %xD800-DBFF.
+    if let Ok(items) = value.extract::<(Bound<'_, PyAny>, Bound<'_, PyAny>)>() {
+        return bad(&items.0).or_else(|| bad(&items.1));
+    }
+    None
+}
+
 #[pyclass(name = "Literal", module = "abnf_rust._ext", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyLiteral {
@@ -226,7 +257,7 @@ pub struct PyLiteral {
 impl PyLiteral {
     #[new]
     #[pyo3(signature = (value, case_sensitive=false))]
-    fn new(value: &Bound<'_, PyAny>, case_sensitive: bool) -> PyResult<Self> {
+    fn new(py: Python<'_>, value: &Bound<'_, PyAny>, case_sensitive: bool) -> PyResult<Self> {
         if let Ok(s) = value.extract::<String>() {
             Ok(Self {
                 inner: Literal::string(s, case_sensitive).into(),
@@ -243,6 +274,21 @@ impl PyLiteral {
                 inner: Literal::range(lo_char, hi_char).into(),
                 case_sensitive: true,
             })
+        } else if let Some(offender) = unrepresentable_str(value) {
+            // A `str` that fails to extract is not a type error.  It
+            // is a string this backend cannot represent: Rust `str`
+            // is well-formed UTF-8, so a lone surrogate (`%xD800` and
+            // friends) has nowhere to go.  Saying "must be a string"
+            // about something that *is* a string sends the reader off
+            // in the wrong direction, so name the real problem.
+            let msg = format!(
+                "the Rust backend cannot represent the literal value {offender}: \
+                 Rust strings are well-formed UTF-8, so surrogate code points \
+                 (%xD800-DFFF) have no representation.  Set ABNF_NO_RUST=1 to \
+                 use the pure-Python backend, which accepts them.  \
+                 See https://github.com/declaresub/abnf/issues/173"
+            );
+            Err(crate::errors::grammar_error(py, &msg))
         } else {
             Err(PyTypeError::new_err(
                 "value argument must be a string or a 2-tuple of strings.",

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -667,6 +667,24 @@ class Rule:
         # `StopIteration` in practice.
         try:
             longest_match = next(g)
+        except UnicodeEncodeError as exc:
+            # Only reachable on the Rust backend, which carries the source
+            # across the FFI as a UTF-8 `&str`.  A Python str may contain lone
+            # surrogates -- from `surrogateescape` on an undecodable filename,
+            # or an unpaired \uD800 out of `json.loads` -- and those have no
+            # UTF-8 representation, so the conversion fails before any parsing
+            # happens.  The pure-Python backend parses such input fine.
+            # Replace the codec traceback, which says nothing about abnf, with
+            # the limitation and its workaround.  See GitHub issue #173.
+            # UnicodeEncodeError is itself a ValueError, so `except ValueError`
+            # callers are unaffected by the re-raise.
+            msg = (
+                "the Rust backend cannot parse input containing lone surrogate "
+                "code points; set ABNF_NO_RUST=1 to use the pure-Python "
+                "backend, which accepts them.  "
+                "See https://github.com/declaresub/abnf/issues/173"
+            )
+            raise ValueError(msg) from exc
         except RecursionError as exc:
             # Deeply-nested input exhausts the Python call stack (the parser is
             # recursive-descent).  Convert to ParseError so the documented
@@ -693,6 +711,21 @@ class Rule:
         :raises ParseError: if source cannot be parsed using rule.
         :raises GrammarError: if rule has no definition.  This usually means that a
             non-terminal in the grammar is not defined or imported.
+
+        .. note::
+            ``source`` is a sequence of Unicode code points, which is what a
+            Python ``str`` is; a terminal value in the grammar (``%x41``,
+            ``%x10000-1FFFD``) is a code-point value.  To parse wire data,
+            decode it with latin-1 -- that maps the 256 byte values onto
+            ``U+0000``-``U+00FF`` one to one, so a code point is exactly an
+            octet and ``OCTET``/``obs-text`` behave as their RFCs describe::
+
+                rule.parse_all(raw.decode("latin-1"))
+
+            The choice of encoding is a semantic one and belongs to the caller:
+            ``b"\\xc3\\xa9"`` is two octets read as latin-1 and one character
+            read as UTF-8, and both readings are correct for some input.  See
+            the "What abnf parses" page in the documentation.
 
         .. note::
             Both backends are recursive-descent and both bound how deeply they

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -298,6 +298,54 @@ def test_x2_non_integer_start_rejected(start: object):
         StartRule("mid").parse("abcdef", start)  # type: ignore[arg-type]
 
 
+# ---------------------------------------------------------------------------
+# Surrogate code points (issue #173).  Rust `str` is well-formed UTF-8 and so
+# cannot hold one; Python `str` can.  The behaviour gap is not fixed here --
+# these tests pin the *diagnosis*, which used to be a TypeError claiming a
+# string was not a string, and a bare codec traceback that never mentioned
+# abnf.  They also record the parity gap itself, so closing #173 will fail
+# them and prompt an update.
+# ---------------------------------------------------------------------------
+
+_BACKEND_IS_RUST = __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust"
+_SURROGATE_SOURCE = b"caf\xe9".decode("utf-8", "surrogateescape")
+
+
+@pytest.mark.skipif(not _BACKEND_IS_RUST, reason="Rust backend only.")
+def test_173_surrogate_grammar_names_the_real_problem():
+    class SurrogateGrammar(Rule):
+        pass
+
+    with pytest.raises(GrammarError) as excinfo:
+        SurrogateGrammar.create("s = %xD800-DBFF")
+    message = str(excinfo.value)
+    assert "surrogate" in message
+    assert "ABNF_NO_RUST" in message
+
+
+@pytest.mark.skipif(not _BACKEND_IS_RUST, reason="Rust backend only.")
+def test_173_surrogate_input_names_the_real_problem():
+    class SurrogateInputGrammar(Rule):
+        pass
+
+    SurrogateInputGrammar.create("s = 1*%x00-10FFFF")
+    with pytest.raises(ValueError) as excinfo:
+        SurrogateInputGrammar("s").parse_all(_SURROGATE_SOURCE)
+    message = str(excinfo.value)
+    assert "surrogate" in message
+    assert "ABNF_NO_RUST" in message
+
+
+@pytest.mark.skipif(_BACKEND_IS_RUST, reason="Pure-Python backend only.")
+def test_173_pure_python_handles_surrogates():
+    # The workaround the messages above point at has to actually work.
+    class SurrogatePythonGrammar(Rule):
+        pass
+
+    SurrogatePythonGrammar.create("s = 1*%x00-10FFFF")
+    assert SurrogatePythonGrammar("s").parse_all(_SURROGATE_SOURCE).value == _SURROGATE_SOURCE
+
+
 def test_option_str():
     assert str(Option(Literal("foo")))
 


### PR DESCRIPTION
Re-lands the second half of #175.

#175 was merged when it contained only its first commit (X2/X4 validation); the docs and error-message commit was pushed to the branch afterwards and never made it into `master`. Same commit, unchanged, on a fresh branch off the merged `master`.

Closes #174. Partially addresses #173 — messages only; the limitation is unchanged and the issue stays open.

---

## 1. The surrogate limitation now explains itself (#173, messages only)

Rust strings are well-formed UTF-8 and cannot hold a surrogate code point. The backend said so badly:

| | before | after |
|---|---|---|
| grammar `%xD800-DBFF` | `TypeError: value argument must be a string or a 2-tuple of strings` — about a value that *was* a string | `GrammarError` naming the surrogate, pointing at `ABNF_NO_RUST=1` |
| input with a lone surrogate | bare `UnicodeEncodeError`, no mention of abnf | `ValueError` naming the cause and the workaround |

Input like that is ordinary: `surrogateescape` is how Python represents undecodable filenames, `sys.argv`, and environment variables, and unpaired `\uD800` survives `json.loads`. **The behaviour is unchanged** — these calls still fail on the Rust backend — but the reader is now pointed at the real cause and a working alternative instead of a codec traceback. #173 stays open for the actual fix.

`UnicodeEncodeError` is itself a `ValueError`, so `except ValueError` callers are unaffected by the re-raise.

## 2. Documentation (#174)

The model was never written down, which is most of why #25 stayed open for two years looking like a missing feature. New `docs/explanation/what-abnf-parses.md`, a note on `Rule.parse_all`, and a README section titled "Parsing bytes" — where someone asking that question will actually look.

The page is explicit that the encoding is a semantic choice the library cannot make for you:

```
raw = b"\xc3\xa9"                        # 'é' as UTF-8
1*OCTET against raw.decode("latin-1")    -> 2 octets   (byte protocol)
1*OCTET against raw.decode("utf-8")      -> 1 octet    (text)
```

## Verification

- 800 differential fuzz cases across 15 bundled grammar rules: **zero divergences**.
- Doc examples were run, not just written: the `request-line` snippet parses, and the `1*OCTET` contrast produces the 2-vs-1 result the page claims. Sphinx builds clean under `-W`.
- 1379 tests pass on the Rust backend and 1378 on pure Python (the difference is the backend-specific `test_173_*` skips); ruff, pyright, and `cargo clippy --all-targets` clean.

## Note

No behaviour changes here — the surrogate calls still fail on the Rust backend, they just say why. The `test_173_*` tests pin the messages *and* record the parity gap, so closing #173 will fail them and prompt an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

