### PR TITLE
Apply rule exclusions to nested references in the Rust engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   pure-Python semantics exactly (a partial match still does not disqualify).
   https://github.com/declaresub/abnf/issues/179
 
+* Document `Rule.exclude_rule`.  Its docstring was reachable in the API
+  reference, but nothing in the guides mentioned it, so the answer to "how do I
+  say an identifier that is not a keyword?" -- a thing ABNF has no operator for
+  -- was undiscoverable.  New how-to covering the recipe, the complete-match
+  semantics, and the fact that it filters candidate matches rather than aborting
+  the parse.
+
 * Memoisation is now scoped to a single parse on both backends, which fixes two
   silent wrong-result bugs and a memory leak at once.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+* `Rule.exclude_rule` now applies to nested rule references under the Rust
+  backend.  It never had: the exclusion lives in the pure-Python `Rule.lparse`,
+  and the Rust engine resolves rule references internally, entering that method
+  only for the rule the caller parses directly.  A grammar written as
+  "identifier, but not a keyword" therefore accepted keywords whenever the
+  keyword rule appeared nested inside another rule -- a validator answering
+  "valid" for input it was written to reject.  `Rule.exclude_rule` now forwards
+  through the bridge the way `Rule.definition` already did, and the engine drops
+  matches whose span parses completely as the excluded rule, matching the
+  pure-Python semantics exactly (a partial match still does not disqualify).
+  https://github.com/declaresub/abnf/issues/179
+
 * Memoisation is now scoped to a single parse on both backends, which fixes two
   silent wrong-result bugs and a memory leak at once.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ and follows the [Diátaxis](https://diataxis.fr/) framework:
 
 - **Tutorial** — *Parse your first header*, a ten-minute end-to-end walkthrough.
 - **How-to guides** — validate input, extract values with visitors, load a grammar
-  from a file, write your own grammar module, use the Rust backend.
+  from a file, write your own grammar module, exclude matches from a rule, use the
+  Rust backend.
 - **Reference** — the public API, the built-in core rules, the bundled grammars, and
   configuration knobs.
 - **Explanation** — what abnf parses (code points, not bytes), the combinator

--- a/docs/how-to/exclude-matches-from-a-rule.md
+++ b/docs/how-to/exclude-matches-from-a-rule.md
@@ -1,0 +1,72 @@
+# Exclude matches from a rule
+
+ABNF has no "everything except" operator. An RFC that needs one usually says so in
+prose — *"an identifier, but not a reserved word"* — and leaves it to the
+implementer. `Rule.exclude_rule` is how you express that here.
+
+```python
+from abnf import ParseError, Rule
+
+class Grammar(Rule):
+    pass
+
+Grammar.create("identifier = ALPHA *(ALPHA / DIGIT)")
+Grammar.create('keyword    = "if" / "else" / "while"')
+
+Grammar("identifier").exclude_rule(Grammar("keyword"))
+
+Grammar("identifier").parse_all("counter")   # fine
+Grammar("identifier").parse_all("while")     # ParseError
+```
+
+The exclusion belongs to the rule, not to the call, so it applies wherever that rule
+is referenced — including from inside other rules:
+
+```python
+Grammar.create("assignment = identifier *WSP \"=\" *WSP identifier")
+
+Grammar("assignment").parse_all("x = y")       # fine
+Grammar("assignment").parse_all("x = while")   # ParseError
+```
+
+## Only a complete match excludes
+
+A match is discarded when the text it consumed parses **entirely** as the excluded
+rule. Text that merely starts with the excluded rule is unaffected:
+
+```python
+Grammar("identifier").parse_all("while")      # ParseError -- exactly the keyword
+Grammar("identifier").parse_all("whileEnd")   # fine -- not the keyword
+```
+
+This is what you want for the keyword case, and it is worth knowing when the excluded
+rule is something more permissive.
+
+## It filters candidates, not the whole parse
+
+`exclude_rule` removes matches from the set a rule offers; it does not abort the
+parse. With an ambiguous rule the shorter matches survive:
+
+```python
+Grammar.create("word = 1*ALPHA")
+Grammar.create('stop = "stop"')
+Grammar("word").exclude_rule(Grammar("stop"))
+
+Grammar("word").parse("stop", 0)       # matches "sto" -- 1*ALPHA also matches
+                                       # the first three letters, and "sto" is
+                                       # not the excluded word
+Grammar("word").parse_all("stop")      # ParseError -- no match reaches the end
+```
+
+So `parse_all` is what turns an exclusion into a rejection. If you are validating,
+you are already using `parse_all` (see {doc}`validate-input`) and this is invisible;
+if you are using `parse`, check the returned offset.
+
+## Notes
+
+- Passing a different rule replaces the exclusion; a rule has at most one.
+- The excluded rule is looked up when it is set, so define it first.
+- Exclusions can be added after the grammar has been used to parse. Earlier releases
+  cached parse results across calls, which could hide a newly-added exclusion; that
+  cache is now scoped to a single parse (see
+  {doc}`../explanation/backtracking-and-caching`).

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -9,4 +9,6 @@ specific goal.
 - {doc}`load-a-grammar-from-a-file` — parse with a grammar kept in a `.abnf` file.
 - {doc}`write-your-own-grammar-module` — define a grammar, including importing rules
   from another.
+- {doc}`exclude-matches-from-a-rule` — express "an X, but not a Y", which ABNF has no
+  operator for.
 - {doc}`use-the-rust-backend` — install, force, and build the optional Rust backend.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ kinds of material, each answering a different need:
   here if you are new: build a working parser end to end.
 - **{doc}`How-to guides <how-to/index>`** — task-oriented recipes for specific goals:
   validate input, walk a parse tree, load a grammar from a file, write your own
-  grammar module, use the Rust backend.
+  grammar module, exclude matches from a rule, use the Rust backend.
 - **{doc}`Reference <reference/index>`** — information-oriented. The public API, the
   built-in core rules, the bundled grammars, and configuration knobs.
 - **{doc}`Explanation <explanation/index>`** — understanding-oriented discussion: the
@@ -53,6 +53,7 @@ how-to/validate-input
 how-to/extract-values-with-visitors
 how-to/load-a-grammar-from-a-file
 how-to/write-your-own-grammar-module
+how-to/exclude-matches-from-a-rule
 how-to/use-the-rust-backend
 ```
 

--- a/packages/abnf-rust/rust/core/src/cache.rs
+++ b/packages/abnf-rust/rust/core/src/cache.rs
@@ -231,6 +231,36 @@ impl Drop for ParseScope {
     }
 }
 
+/// Marks a sub-parse over a *different* source inside the current
+/// parse: rule exclusion re-parses a matched span against the
+/// excluded rule.
+///
+/// Cache entries are keyed by position and scoped by epoch, which
+/// assumes one epoch sees one source.  A sub-parse over other text
+/// therefore has to claim its own epoch, or its positions would
+/// collide with the enclosing parse's.  The outer epoch is restored
+/// on drop; caches the sub-parse touched are reset when the outer
+/// parse next reaches them, so it costs hit rate in grammars that use
+/// exclusions and nothing at all in grammars that do not.
+pub struct SourceScope {
+    previous: u64,
+}
+
+impl SourceScope {
+    pub fn enter() -> Self {
+        let previous = CURRENT_EPOCH.with(Cell::get);
+        let claimed = EPOCH_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+        CURRENT_EPOCH.with(|epoch| epoch.set(claimed));
+        Self { previous }
+    }
+}
+
+impl Drop for SourceScope {
+    fn drop(&mut self) {
+        CURRENT_EPOCH.with(|epoch| epoch.set(self.previous));
+    }
+}
+
 /// The epoch currently being parsed under.
 pub fn current_epoch() -> u64 {
     CURRENT_EPOCH.with(Cell::get)

--- a/packages/abnf-rust/rust/core/src/lib.rs
+++ b/packages/abnf-rust/rust/core/src/lib.rs
@@ -40,7 +40,7 @@ mod rule;
 mod visitor;
 
 pub use alternation::Alternation;
-pub use cache::{ParseCache, ParseScope};
+pub use cache::{ParseCache, ParseScope, SourceScope};
 pub use concatenation::Concatenation;
 pub use core_rules::install_core_rules;
 pub use error::ParseError;

--- a/packages/abnf-rust/rust/core/src/rule.rs
+++ b/packages/abnf-rust/rust/core/src/rule.rs
@@ -147,6 +147,11 @@ impl Drop for DepthGuard {
 pub struct NamedRule {
     pub name: Arc<str>,
     definition: RwLock<Option<ArcParser>>,
+    /// Rule whose complete matches disqualify this rule's matches --
+    /// `Rule.exclude_rule`, the ABNF idiom for "identifier, but not a
+    /// keyword".  `None` for the overwhelming majority of rules, and
+    /// checked with a single `Option` test on the match path.
+    exclude: RwLock<Option<Arc<NamedRule>>>,
     /// Pre-formatted error description (`"Rule(<name>)"`), computed
     /// once at construction and cloned cheaply (Arc bump) on every
     /// failed parse.  Without this, alternation backtracking through
@@ -162,7 +167,38 @@ impl NamedRule {
         Self {
             name,
             definition: RwLock::new(None),
+            exclude: RwLock::new(None),
             error_label,
+        }
+    }
+
+    /// Set (or clear) the exclusion.  Mirrors `Rule.exclude_rule` on
+    /// the Python side, which the dispatch shim forwards here so the
+    /// engine sees exclusions on nested rule references and not just
+    /// on whichever rule the caller happened to parse directly.
+    pub fn set_exclude(&self, rule: Option<Arc<NamedRule>>) {
+        *self.exclude.write().unwrap_or_else(|e| e.into_inner()) = rule;
+    }
+
+    fn exclude(&self) -> Option<Arc<NamedRule>> {
+        self.exclude
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Whether `text` parses completely as the excluded rule.
+    ///
+    /// Mirrors the pure-Python check, which runs `parse_all` over the
+    /// matched value: a partial match does not disqualify anything.
+    fn is_excluded(excluded: &NamedRule, text: &str) -> bool {
+        // The sub-parse runs over different text inside the current
+        // parse, so it needs its own epoch -- position-keyed cache
+        // entries from the two must not mix.
+        let _scope = crate::cache::SourceScope::enter();
+        match excluded.lparse(text, 0) {
+            Ok(matches) => matches.iter().any(|m| m.start == text.len()),
+            Err(_) => false,
         }
     }
 
@@ -171,10 +207,7 @@ impl NamedRule {
         // code path left it poisoned, we still want to record the
         // new definition rather than permanently brick every parse
         // that touches this rule.
-        *self
-            .definition
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = Some(def);
+        *self.definition.write().unwrap_or_else(|e| e.into_inner()) = Some(def);
     }
 
     pub fn definition(&self) -> Option<ArcParser> {
@@ -227,9 +260,11 @@ impl NamedRule {
         let def = self.definition().ok_or_else(|| self.parse_error(start))?;
         let inner = def.lparse(source, start)?;
 
-        // Hot path: most rules produce exactly one match.  Skip the
-        // dedup allocation entirely.
-        if inner.len() == 1 {
+        let excluded = self.exclude();
+
+        // Hot path: most rules produce exactly one match and have no
+        // exclusion.  Skip the dedup allocation entirely.
+        if inner.len() == 1 && excluded.is_none() {
             let m = inner.into_iter().next().expect("len == 1");
             let node = Node::new(self.name.clone(), m.nodes.into_vec());
             return Ok(smallvec![Match::new(
@@ -238,18 +273,25 @@ impl NamedRule {
             )]);
         }
 
-        // Multi-match (ambiguous grammar): dedup by end position.
+        // Multi-match (ambiguous grammar) or an exclusion to apply:
+        // dedup by end position, dropping matches whose span parses
+        // completely as the excluded rule.
         let mut seen: HashSet<usize> = HashSet::new();
         let mut wrapped: MatchList = SmallVec::with_capacity(inner.len());
         for m in inner {
             if !seen.insert(m.start) {
                 continue;
             }
+            if let Some(ref excluded) = excluded {
+                // `m.start` is the end of the match; the span is what
+                // the Python side rebuilds by joining node values.
+                if Self::is_excluded(excluded, &source[start..m.start]) {
+                    seen.remove(&m.start);
+                    continue;
+                }
+            }
             let node = Node::new(self.name.clone(), m.nodes.into_vec());
-            wrapped.push(Match::new(
-                smallvec![NodeKind::Internal(node)],
-                m.start,
-            ));
+            wrapped.push(Match::new(smallvec![NodeKind::Internal(node)], m.start));
         }
         if wrapped.is_empty() {
             Err(self.parse_error(start))

--- a/packages/abnf-rust/rust/core/tests/exclusion.rs
+++ b/packages/abnf-rust/rust/core/tests/exclusion.rs
@@ -1,0 +1,94 @@
+//! `NamedRule` exclusions (issue #179).
+//!
+//! Mirrors `Rule.exclude_rule` in the pure-Python backend: a match is
+//! dropped when its span parses *completely* as the excluded rule.
+//! The engine has to apply this to nested rule references, since it
+//! resolves those internally and never returns to the Python
+//! `Rule.lparse` that used to be the only place exclusions lived.
+
+use std::sync::Arc;
+
+use abnf_core::{ArcParser, Literal, NamedRule, ParseScope, Repeat, Repetition};
+
+/// `ident = 1*%x61-7A`
+fn ident_rule() -> Arc<NamedRule> {
+    let rule = Arc::new(NamedRule::new("ident"));
+    let letter: ArcParser = Literal::range('a', 'z').into();
+    rule.set_definition(Repetition::new(Repeat::new(1, None), letter).into());
+    rule
+}
+
+/// `kw = "foo"`
+fn keyword_rule() -> Arc<NamedRule> {
+    let rule = Arc::new(NamedRule::new("kw"));
+    rule.set_definition(Literal::string("foo", false).into());
+    rule
+}
+
+fn longest(rule: &NamedRule, source: &str) -> Option<usize> {
+    let _scope = ParseScope::enter();
+    rule.lparse(source, 0)
+        .ok()
+        .and_then(|matches| matches.iter().map(|m| m.start).max())
+}
+
+/// Whether the rule matches the whole of `source` -- the `parse_all`
+/// question, and the one exclusions are really about.
+fn matches_all(rule: &NamedRule, source: &str) -> bool {
+    longest(rule, source) == Some(source.len())
+}
+
+#[test]
+fn exclusion_rejects_a_complete_match() {
+    let ident = ident_rule();
+    ident.set_exclude(Some(keyword_rule()));
+    assert!(
+        !matches_all(&ident, "foo"),
+        "the excluded keyword was accepted"
+    );
+    // Only the full-span match is dropped.  `1*ALPHA` also matches
+    // "f" and "fo", neither of which is the keyword, so those
+    // survive -- exactly what the pure-Python backend yields
+    // (verified: both produce ends [2, 1]).  `parse_all` still fails,
+    // because the longest survivor does not reach the end.
+    assert_eq!(longest(&ident, "foo"), Some(2));
+}
+
+#[test]
+fn exclusion_leaves_other_input_alone() {
+    let ident = ident_rule();
+    ident.set_exclude(Some(keyword_rule()));
+    assert!(matches_all(&ident, "bar"));
+}
+
+#[test]
+fn a_partial_match_does_not_exclude() {
+    // "foobar" starts with the keyword but is not the keyword; the
+    // Python side runs parse_all over the matched value, so only a
+    // complete match disqualifies.
+    let ident = ident_rule();
+    ident.set_exclude(Some(keyword_rule()));
+    assert!(matches_all(&ident, "foobar"));
+}
+
+#[test]
+fn exclusion_can_be_cleared_and_replaced() {
+    let ident = ident_rule();
+    ident.set_exclude(Some(keyword_rule()));
+    assert!(!matches_all(&ident, "foo"));
+
+    ident.set_exclude(None);
+    assert!(matches_all(&ident, "foo"), "clearing had no effect");
+
+    let other = Arc::new(NamedRule::new("other"));
+    other.set_definition(Literal::string("bar", false).into());
+    ident.set_exclude(Some(other));
+    assert!(matches_all(&ident, "foo"));
+    assert!(!matches_all(&ident, "bar"));
+}
+
+#[test]
+fn a_rule_with_no_exclusion_is_unaffected() {
+    let ident = ident_rule();
+    assert!(matches_all(&ident, "foo"));
+}

--- a/packages/abnf-rust/rust/pyo3/src/bridge.rs
+++ b/packages/abnf-rust/rust/pyo3/src/bridge.rs
@@ -60,6 +60,26 @@ pub fn set_definition_for(
     Ok(())
 }
 
+/// Point the `NamedRule` for `py_rule` at the `NamedRule` for
+/// `py_excluded`, so the engine applies `Rule.exclude_rule` to nested
+/// rule references.  Before this, the exclusion lived only in the
+/// pure-Python `Rule.lparse`, which the Rust path enters just once
+/// per parse -- for the top-level rule -- so a nested exclusion was
+/// silently ignored and the grammar accepted what it was written to
+/// reject (issue #179).
+pub fn set_exclude_for(
+    py_rule: &Bound<'_, PyAny>,
+    py_excluded: Option<&Bound<'_, PyAny>>,
+) -> PyResult<()> {
+    let handle = get_or_create(py_rule)?;
+    let excluded = match py_excluded {
+        Some(rule) => Some(get_or_create(rule)?),
+        None => None,
+    };
+    handle.set_exclude(excluded);
+    Ok(())
+}
+
 /// Drop every entry in the bridge registry.
 ///
 /// The registry holds one `Arc<NamedRule>` (plus its parser tree) for

--- a/packages/abnf-rust/rust/pyo3/src/hooks.rs
+++ b/packages/abnf-rust/rust/pyo3/src/hooks.rs
@@ -3,19 +3,28 @@
 //! When the Rust backend is active, the dispatch shim wires
 //! [`set_definition_hook`] onto `Rule._set_definition_hook` so that
 //! every `rule.definition = value` write keeps the Rust shadow
-//! registry of `NamedRule` handles in sync.
+//! registry of `NamedRule` handles in sync, and [`set_exclude_hook`]
+//! onto `Rule._set_exclude_hook` so `Rule.exclude_rule` reaches the
+//! engine too.
 
 use pyo3::prelude::*;
 
-use crate::bridge::set_definition_for;
+use crate::bridge::{set_definition_for, set_exclude_for};
 use crate::parsers::extract_parser;
 
 #[pyfunction]
-pub fn set_definition_hook(
-    rule: &Bound<'_, PyAny>,
-    definition: &Bound<'_, PyAny>,
-) -> PyResult<()> {
+pub fn set_definition_hook(rule: &Bound<'_, PyAny>, definition: &Bound<'_, PyAny>) -> PyResult<()> {
     let parser = extract_parser(definition)?;
     set_definition_for(rule, parser)?;
+    Ok(())
+}
+
+#[pyfunction]
+#[pyo3(signature = (rule, excluded=None))]
+pub fn set_exclude_hook(
+    rule: &Bound<'_, PyAny>,
+    excluded: Option<&Bound<'_, PyAny>>,
+) -> PyResult<()> {
+    set_exclude_for(rule, excluded)?;
     Ok(())
 }

--- a/packages/abnf-rust/rust/pyo3/src/lib.rs
+++ b/packages/abnf-rust/rust/pyo3/src/lib.rs
@@ -49,6 +49,7 @@ fn _ext(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Functions
     m.add_function(wrap_pyfunction!(bootstrap::bootstrap, m)?)?;
     m.add_function(wrap_pyfunction!(hooks::set_definition_hook, m)?)?;
+    m.add_function(wrap_pyfunction!(hooks::set_exclude_hook, m)?)?;
     m.add_function(wrap_pyfunction!(bridge::clear_bridge, m)?)?;
     m.add_function(wrap_pyfunction!(bridge::bridge_size, m)?)?;
 

--- a/packages/abnf-rust/src/abnf_rust/__init__.py
+++ b/packages/abnf-rust/src/abnf_rust/__init__.py
@@ -26,6 +26,7 @@ from abnf_rust._ext import (  # type: ignore[import-not-found]
     Repetition,
     bootstrap,
     set_definition_hook,
+    set_exclude_hook,
 )
 
 #: Signals to :mod:`abnf.parser` that the compiled extension exposes
@@ -54,4 +55,5 @@ __all__ = [
     "__version__",
     "bootstrap",
     "set_definition_hook",
+    "set_exclude_hook",
 ]

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -634,6 +634,14 @@ class Rule:
         typing.Callable[[Rule, Parser], None] | None
     ] = None
 
+    #: Optional hook invoked on every ``rule.exclude_rule(...)`` call,
+    #: so the Rust engine can apply exclusions to nested rule
+    #: references.  Unset for the pure-Python backend, which applies
+    #: them directly in ``Rule.lparse``.
+    _set_exclude_hook: typing.ClassVar[typing.Callable[[Rule, Rule], None] | None] = (
+        None
+    )
+
     @property
     def first_match_alternation(self) -> bool:
         try:
@@ -673,6 +681,14 @@ class Rule:
         Then attempting to use "foo" as an identifier would result in a ParseError.
         """
         self.exclude = rule
+        # Forward to the engine, the same way `definition` does.  The
+        # exclusion is applied in `Rule.lparse` below, which the Rust
+        # backend enters only for the rule the caller parses directly --
+        # so without this hook an exclusion on a *nested* rule reference
+        # was silently ignored there.  See GitHub issue #179.
+        hook = getattr(type(self), "_set_exclude_hook", None)
+        if hook is not None:
+            hook(self, rule)
 
     def lparse(self, source: Source, start: int) -> Matches:
         def exclude(match: Match) -> bool:

--- a/src/abnf/parser.py
+++ b/src/abnf/parser.py
@@ -109,6 +109,7 @@ if _BACKEND == "rust":
     # this, rule references in user grammars dispatch through Python's
     # `Rule.lparse` on every call, bottlenecking the Rust engine.
     Rule._set_definition_hook = staticmethod(_backend.set_definition_hook)
+    Rule._set_exclude_hook = staticmethod(_backend.set_exclude_hook)
     # Replace the pure-Python combinator trees registered into
     # ABNFGrammarRule._obj_map at _parser_python import time with
     # Rust-backed equivalents.  See abnf_rust.bootstrap.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -154,15 +154,6 @@ def test_parse_cache_max_cache_size_assignment_is_deprecated():
 # ---------------------------------------------------------------------------
 
 
-_RUST_NO_NESTED_EXCLUDE = pytest.mark.skipif(
-    __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
-    reason="Rule.exclude_rule is not implemented in the Rust engine for nested "
-    "rule references -- the exclusion lives in the pure-Python Rule.lparse, "
-    "which the Rust path enters only for the top-level rule.  Not a cache "
-    "issue; tracked separately.",
-)
-
-
 def test_h1_incremental_definition_is_not_masked_by_a_stale_cache():
     class IncrementalRule(Rule):
         pass
@@ -176,7 +167,6 @@ def test_h1_incremental_definition_is_not_masked_by_a_stale_cache():
     assert IncrementalRule("word").parse_all("ab").value == "ab"
 
 
-@_RUST_NO_NESTED_EXCLUDE
 def test_h1_exclude_rule_is_not_masked_by_a_stale_cache():
     class ExcludeAfterParseRule(Rule):
         pass
@@ -215,7 +205,6 @@ def test_parse_memo_does_not_outlive_the_parse():
     assert _parser_python._parse_memo.get() is None
 
 
-@_RUST_NO_NESTED_EXCLUDE
 def test_nested_parse_restores_the_outer_memo():
     # Rule.lparse runs exclude.parse_all on a *different* source mid-parse.
     # The inner parse must bind its own memo and hand the outer one back,
@@ -232,6 +221,59 @@ def test_nested_parse_restores_the_outer_memo():
     with pytest.raises(ParseError):
         NestedParseRule("phrase").parse_all("foo.")
     assert _parser_python._parse_memo.get() is None
+
+
+# ---------------------------------------------------------------------------
+# #179: exclusions must apply to nested rule references, not only to whichever
+# rule the caller parses directly.  The Rust engine resolves rule references
+# internally and enters the pure-Python Rule.lparse just once per parse, so
+# before the bridge forwarded exclusions it silently accepted what the grammar
+# was written to reject.
+# ---------------------------------------------------------------------------
+
+
+def _keyword_grammar():
+    class KeywordGrammar(Rule):
+        pass
+
+    KeywordGrammar.create("ident = 1*%x61-7A")
+    KeywordGrammar.create('kw = "foo"')
+    KeywordGrammar.create('phrase = 1*(ident ".")')
+    KeywordGrammar("ident").exclude_rule(KeywordGrammar("kw"))
+    return KeywordGrammar
+
+
+def test_179_exclusion_applies_to_nested_rule_references():
+    grammar = _keyword_grammar()
+    with pytest.raises(ParseError):
+        grammar("phrase").parse_all("foo.")
+
+
+def test_179_exclusion_leaves_other_input_alone():
+    grammar = _keyword_grammar()
+    assert grammar("phrase").parse_all("bar.").value == "bar."
+
+
+def test_179_partial_match_does_not_exclude():
+    # The Python side runs `parse_all` over the matched value, so only a
+    # complete match disqualifies: "foobar" is not the keyword "foo".
+    grammar = _keyword_grammar()
+    assert grammar("ident").parse_all("foobar").value == "foobar"
+
+
+def test_179_exclusion_can_be_replaced():
+    class ReplaceExcludeGrammar(Rule):
+        pass
+
+    ReplaceExcludeGrammar.create("ident = 1*%x61-7A")
+    ReplaceExcludeGrammar.create('kw = "foo"')
+    ReplaceExcludeGrammar.create('other = "bar"')
+    ReplaceExcludeGrammar("ident").exclude_rule(ReplaceExcludeGrammar("kw"))
+    ReplaceExcludeGrammar("ident").exclude_rule(ReplaceExcludeGrammar("other"))
+
+    assert ReplaceExcludeGrammar("ident").parse_all("foo").value == "foo"
+    with pytest.raises(ParseError):
+        ReplaceExcludeGrammar("ident").parse_all("bar")
 
 
 def test_parseerror_str():


### PR DESCRIPTION
Closes #179.

`Rule.exclude_rule` was silently ignored for nested rule references whenever the Rust backend was active. A grammar written as "identifier, but not a keyword" accepted keywords — a validator answering *valid* for input it exists to reject, which is the worst direction for a parser to fail in.

```python
G.create("ident = 1*%x61-7A")
G.create('kw = "foo"')
G.create('phrase = 1*(ident ".")')
G("ident").exclude_rule(G("kw"))

G("phrase").parse_all("foo.")
# pure Python: ParseError        Rust: parses
```

## Cause

The exclusion lived only in the pure-Python `Rule.lparse`. The engine resolves rule references internally through `NamedRule` and returns to that method just **once per parse** — for the rule the caller parses directly — so nested exclusions were never consulted. `grep -rn exclude packages/abnf-rust/rust/` returned nothing: the concept did not exist in the engine.

Not a cache bug, though it was filed as one. July's analysis recorded this reproducer under C1 as "stale cache after `exclude_rule`, reproduced on both backends"; on Rust the exclusion was never applied at all. Fixing cache scoping in #180 repaired the other two C1 reproducers there and left this one failing, which is what exposed it.

## The change

`exclude_rule` now forwards through the bridge exactly as `definition` writes already did — a `_set_exclude_hook` classvar mirroring `_set_definition_hook`, wired by the dispatch shim, reaching `NamedRule::set_exclude`. `NamedRule::lparse` drops matches whose span parses **completely** as the excluded rule, which is the pure-Python rule (`parse_all` over the matched value), so a partial match disqualifies nothing.

**The check needs its own epoch.** Cache entries are keyed by position and scoped to a parse on the assumption that one epoch sees one source. The exclusion re-parses a matched span — different text inside the enclosing parse — so `SourceScope` claims a fresh epoch and restores the outer one on drop. Without that, the sub-parse's positions would collide with the enclosing parse's.

Grammars without exclusions are untouched: the hot path takes a single `Option` test, and the benchmarks are unchanged (62.1 / 337.0 / 20.2 / 7.9 µs against 62.4 / 332.2 / 20.5 / 7.9 before).

## Verification

Seven cases, identical on both backends: nested exclusion, exclusion applied after a warming parse, non-excluded input still parsing, partial vs complete match, and replacing an existing exclusion.

Worth recording one correction: a Rust unit test asserting the excluded rule matched *nothing* turned out to be wrong, not the code. Dropping the full-span match leaves the shorter ones, so `ident` over `"foo"` still yields match ends `[2, 1]` and it is `parse_all` that fails. Both backends produce exactly that — verified directly — and the test now says so.

Also unskips the two tests parked on this in #180, and adds four Python tests plus five Rust unit tests.

- 1,389 tests (Rust) / 1,388 (Python), 2,469 + 3,550 fuzz tests, 54 Rust tests
- 800 differential cases, zero divergences; concurrency and cross-source checks from #180 still clean
- clippy, ruff, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
