### PR TITLE
Make Rule.exclude a property, and report undefined excluded rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@
   pure-Python semantics exactly (a partial match still does not disqualify).
   https://github.com/declaresub/abnf/issues/179
 
+* `Rule.exclude` is now a property whose setter notifies the backend, mirroring
+  `Rule.definition`, and `Rule.exclude_rule` is a thin wrapper over it.  Only the
+  method used to notify, so on the Rust backend `rule.exclude = None` cleared the
+  exclusion for the pure-Python parser while the engine went on applying it, and
+  assigning `rule.exclude = other` was ignored entirely.  Assignment is the only
+  way to *remove* an exclusion, so that was the case most likely to be hit.
+
+* An exclusion naming a rule that has no definition now raises `GrammarError` on
+  both backends.  The Rust engine treated the missing definition as an ordinary
+  parse failure -- "not excluded" -- and accepted input the grammar was written
+  to reject.
+
 * Document `Rule.exclude_rule`.  Its docstring was reachable in the API
   reference, but nothing in the guides mentioned it, so the answer to "how do I
   say an identifier that is not a keyword?" -- a thing ABNF has no operator for

--- a/packages/abnf-rust/rust/core/src/rule.rs
+++ b/packages/abnf-rust/rust/core/src/rule.rs
@@ -192,6 +192,17 @@ impl NamedRule {
     /// Mirrors the pure-Python check, which runs `parse_all` over the
     /// matched value: a partial match does not disqualify anything.
     fn is_excluded(excluded: &NamedRule, text: &str) -> bool {
+        // An exclusion naming a rule that was never defined is a
+        // broken grammar, not an input that failed to match.  The
+        // pure-Python backend raises GrammarError here; without this
+        // check the missing definition would surface as an ordinary
+        // parse failure, i.e. "not excluded", and the grammar would
+        // silently accept what it was written to reject.  Panic with
+        // the phrase the PyO3 layer maps to GrammarError, the same
+        // route the recursion guard uses.
+        if excluded.definition().is_none() {
+            panic!("Undefined rule \"{}\"", excluded.name);
+        }
         // The sub-parse runs over different text inside the current
         // parse, so it needs its own epoch -- position-keyed cache
         // entries from the two must not mix.

--- a/packages/abnf-rust/rust/pyo3/src/recursion.rs
+++ b/packages/abnf-rust/rust/pyo3/src/recursion.rs
@@ -42,6 +42,11 @@ const DEPTH_PANIC_TAG: &str = "maximum rule recursion depth exceeded";
 /// flow signal across the Rust core.
 const PYERR_PANIC_TAG: &str = "pycallback-python-error";
 
+/// Substring identifying the panic raised when an exclusion names a
+/// rule that has no definition.  Matches the message the pure-Python
+/// `Rule.lparse` raises as `GrammarError`.
+const UNDEFINED_RULE_TAG: &str = "Undefined rule";
+
 thread_local! {
     /// Holds the most recent `PyErr` raised by a `PyCallbackParser`
     /// callback that should propagate (i.e. not a `ParseError`).
@@ -63,7 +68,10 @@ pub fn install_panic_hook() {
                 .map(String::as_str)
                 .or_else(|| info.payload().downcast_ref::<&'static str>().copied())
                 .unwrap_or("");
-            if message.contains(DEPTH_PANIC_TAG) || message.contains(PYERR_PANIC_TAG) {
+            if message.contains(DEPTH_PANIC_TAG)
+                || message.contains(PYERR_PANIC_TAG)
+                || message.contains(UNDEFINED_RULE_TAG)
+            {
                 // Suppress the default hook's stderr output for these
                 // specific panics — they're about to be caught and
                 // re-raised as ordinary Python exceptions, so the
@@ -110,6 +118,8 @@ where
             let message = payload_message(&payload);
             if message.contains(DEPTH_PANIC_TAG) {
                 Err(PyRecursionError::new_err(message))
+            } else if message.contains(UNDEFINED_RULE_TAG) {
+                Python::attach(|py| Err(crate::errors::grammar_error(py, &message)))
             } else if message.contains(PYERR_PANIC_TAG) {
                 let err = PENDING_PYERR.with(|cell| cell.borrow_mut().take());
                 Err(err.unwrap_or_else(|| {

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -600,9 +600,12 @@ class Rule:
         except AttributeError:
             self.name = name
         try:
-            _ = self.exclude
+            _ = self._exclude
         except AttributeError:
-            self.exclude: Rule | None = None
+            # Assign the private slot, not the property: an unset
+            # exclusion is the default state and there is nothing for
+            # the backend to be told about.
+            self._exclude: Rule | None = None
 
         if definition is not None:
             # when defined-as = '=/', we'll need to overwrite existing definition.
@@ -634,13 +637,39 @@ class Rule:
         typing.Callable[[Rule, Parser], None] | None
     ] = None
 
-    #: Optional hook invoked on every ``rule.exclude_rule(...)`` call,
-    #: so the Rust engine can apply exclusions to nested rule
-    #: references.  Unset for the pure-Python backend, which applies
-    #: them directly in ``Rule.lparse``.
-    _set_exclude_hook: typing.ClassVar[typing.Callable[[Rule, Rule], None] | None] = (
-        None
-    )
+    @property
+    def exclude(self) -> Rule | None:
+        """Rule whose complete matches disqualify this rule's matches.
+
+        ``None`` unless set.  Backed by ``self._exclude``; like
+        ``definition``, the property setter forwards writes through
+        ``Rule._set_exclude_hook`` (when set) so the Rust engine
+        applies the exclusion to nested rule references too.
+
+        Assigning here and calling :meth:`exclude_rule` are the same
+        operation -- that is the point of the property.  Before it
+        existed only the method notified the backend, so
+        ``rule.exclude = None`` cleared the exclusion for the
+        pure-Python parser while the Rust engine went on applying it.
+        """
+
+        return self._exclude
+
+    @exclude.setter
+    def exclude(self, value: Rule | None) -> None:
+        self._exclude = value
+        hook = getattr(type(self), "_set_exclude_hook", None)
+        if hook is not None:
+            hook(self, value)
+
+    #: Optional hook invoked on every write to ``exclude`` (including
+    #: via :meth:`exclude_rule`), so the Rust engine can apply
+    #: exclusions to nested rule references.  Unset for the
+    #: pure-Python backend, which applies them directly in
+    #: ``Rule.lparse``.
+    _set_exclude_hook: typing.ClassVar[
+        typing.Callable[[Rule, Rule | None], None] | None
+    ] = None
 
     @property
     def first_match_alternation(self) -> bool:
@@ -679,16 +708,11 @@ class Rule:
             Rule('identifier').exclude_rule(Rule('keyword'))
 
         Then attempting to use "foo" as an identifier would result in a ParseError.
+
+        Equivalent to assigning :attr:`exclude`; assign ``None`` there to
+        remove an exclusion.
         """
         self.exclude = rule
-        # Forward to the engine, the same way `definition` does.  The
-        # exclusion is applied in `Rule.lparse` below, which the Rust
-        # backend enters only for the rule the caller parses directly --
-        # so without this hook an exclusion on a *nested* rule reference
-        # was silently ignored there.  See GitHub issue #179.
-        hook = getattr(type(self), "_set_exclude_hook", None)
-        if hook is not None:
-            hook(self, rule)
 
     def lparse(self, source: Source, start: int) -> Matches:
         def exclude(match: Match) -> bool:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -276,6 +276,49 @@ def test_179_exclusion_can_be_replaced():
         ReplaceExcludeGrammar("ident").parse_all("bar")
 
 
+def _nested_keyword_grammar():
+    """`ident` appears only *inside* `phrase`, so the exclusion is
+    exercised through a nested reference -- the case the Rust engine
+    used to ignore, and the only one that tells the backends apart."""
+
+    class NestedKeywordGrammar(Rule):
+        pass
+
+    NestedKeywordGrammar.create("ident = 1*%x61-7A")
+    NestedKeywordGrammar.create('kw = "foo"')
+    NestedKeywordGrammar.create('phrase = 1*(ident ".")')
+    return NestedKeywordGrammar
+
+
+def test_179_exclusion_is_cleared_by_assigning_none():
+    grammar = _nested_keyword_grammar()
+    grammar("ident").exclude_rule(grammar("kw"))
+    with pytest.raises(ParseError):
+        grammar("phrase").parse_all("foo.")
+
+    # `exclude` is a property whose setter notifies the backend, so
+    # clearing works through the attribute as well as the method.
+    grammar("ident").exclude = None
+    assert grammar("phrase").parse_all("foo.").value == "foo."
+
+
+def test_179_exclusion_can_be_set_by_assigning_the_attribute():
+    grammar = _nested_keyword_grammar()
+    grammar("ident").exclude = grammar("kw")
+    with pytest.raises(ParseError):
+        grammar("phrase").parse_all("foo.")
+
+
+def test_179_excluding_an_undefined_rule_is_a_grammar_error():
+    # Not "the input did not match": the grammar names a rule that was
+    # never defined, which both backends must report as such rather
+    # than quietly accepting the input.
+    grammar = _nested_keyword_grammar()
+    grammar("ident").exclude_rule(grammar("never-defined"))
+    with pytest.raises(GrammarError):
+        grammar("phrase").parse_all("foo.")
+
+
 def test_parseerror_str():
     # I'm not checking the output, just exercising ParseError.__str__ .
     assert str(ParseError(Literal("a"), 1))


### PR DESCRIPTION
Follow-up to #181, which merged while this commit was still in flight — it was pushed to that branch afterwards and never landed. Same commit, rebased onto master.

Three divergences in the exclusion API, all visible only when the excluded rule is **nested** inside another rule, which is where the Rust engine rather than the pure-Python `Rule.lparse` decides:

| case | pure Python | Rust (before) |
|---|---|---|
| `exclude_rule(kw)` then `rule.exclude = None` | clears | still excludes |
| `rule.exclude = kw` (attribute, no method call) | excludes | ignored |
| excluding a rule with no definition | `GrammarError` | silently parses |

## Cause and fix

`exclude` was a plain attribute while `definition` is a property with a hook, so #181 hooked the *method* instead. Assignment — the only way to **remove** an exclusion — silently didn't reach the engine.

`exclude` is now a property whose setter forwards through `_set_exclude_hook` exactly as `definition` does, and `exclude_rule` is a one-line wrapper over it. Both mutable parts of a `Rule` now behave the same way, with a single place where the backend is notified. Initialisation assigns the private slot so constructing a rule doesn't fire the hook.

Separately, an exclusion naming an undefined rule was treated by the engine as an ordinary parse failure — "not excluded" — so the grammar accepted what it was written to reject. That is the same silent-acceptance shape as #179 itself, one level down. The engine now checks for a missing definition and panics with the phrase the PyO3 layer maps to `GrammarError`, the route the recursion guard already uses.

## Verification

All three behave identically on both backends now, with regression tests using a nested grammar — the only shape that distinguishes them, and the reason my first probe of this API wrongly came back clean.

1,392 tests on Rust / 1,391 on Python, 54 Rust tests, 800 differential cases with zero divergences, benchmarks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
