### PR TITLE
Build a repetition's min-prefix parser once, in the Rust engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* The Rust engine builds a repetition's mandatory-prefix parser once, at
+  construction, rather than rebuilding it on every cache miss.  `1*X` is the most
+  common repetition in any grammar, and each miss allocated a `Vec` plus a
+  `Concatenation` that depended only on values fixed when the `Repetition` was
+  created.  The pure-Python backend was fixed the same way earlier in this
+  release; this brings the two into line.  No measurable speed change -- for
+  `min = 1` the discarded allocation is one `Arc` clone and a one-element `Vec`,
+  which does not register against the parsing work at any input size tested.
+
 * `Rule.exclude_rule` now applies to nested rule references under the Rust
   backend.  It never had: the exclusion lives in the pure-Python `Rule.lparse`,
   and the Rust engine resolves rule references internally, entering that method

--- a/packages/abnf-rust/rust/core/src/repetition.rs
+++ b/packages/abnf-rust/rust/core/src/repetition.rs
@@ -30,14 +30,33 @@ impl Repeat {
 pub struct Repetition {
     pub repeat: Repeat,
     pub element: ArcParser,
+    /// The `min` mandatory repetitions, as a single `Concatenation`.
+    /// `None` when `min` is zero.
+    ///
+    /// Depends only on `element` and `repeat.min`, both fixed at
+    /// construction, so it is built once here rather than on every
+    /// parse -- `1*X` is the most common repetition in any grammar,
+    /// and rebuilding it allocated a `Vec` plus a `Concatenation` per
+    /// call.  The pure-Python backend had the same wart, fixed the
+    /// same way.
+    ///
+    /// `Repeat` is `Copy` with public fields; nothing in the library
+    /// mutates one after handing it to `Repetition`, and a caller who
+    /// did would need to rebuild the `Repetition` too.
+    min_parser: Option<ArcParser>,
     cache: Mutex<ParseCache>,
 }
 
 impl Repetition {
     pub fn new(repeat: Repeat, element: ArcParser) -> Self {
+        let min_parser = (repeat.min > 0).then(|| {
+            let parsers = vec![element.clone(); repeat.min];
+            ArcParser::from(Concatenation::new(parsers))
+        });
         Self {
             repeat,
             element,
+            min_parser,
             cache: Mutex::new(ParseCache::default()),
         }
     }
@@ -68,21 +87,19 @@ impl Repetition {
         let mut match_set: MatchList = if self.repeat.min == 0 {
             smallvec![Match::new(SmallVec::new(), start)]
         } else {
-            let parsers = vec![self.element.clone(); self.repeat.min];
-            let concat = Concatenation::new(parsers);
+            // Non-zero `min` implies `min_parser` was built.
+            let concat = self
+                .min_parser
+                .as_ref()
+                .expect("min_parser is Some whenever repeat.min > 0");
             match concat.lparse(source, start) {
                 Ok(ms) => ms,
                 Err(_) => {
                     let err = ParseError::new("Repetition", start);
-                    // Tolerate a poisoned mutex: a panic in some unrelated
-            // earlier code path must not permanently brick this rule.
-            // The cache is purely a hit-rate optimisation; stale
-            // entries left over by a poisoned holder only cost us a
-            // miss on the next lookup.
-            let mut cache = self
-                .cache
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+                    // Tolerate a poisoned mutex, as above: a stale
+                    // entry left by a poisoned holder costs a miss,
+                    // never a wrong answer.
+                    let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
                     cache.put(start, CachedResult::Failed(err.clone()));
                     return Err(err);
                 }


### PR DESCRIPTION
C6 from the July cache analysis — the half that was only ever fixed on the Python side.

`Repetition::lparse` rebuilt `vec![element.clone(); min]` plus a `Concatenation` on every cache miss, though both inputs are fixed when the `Repetition` is constructed. `1*X` is the most common repetition in any grammar, so this ran often. It is now built once, in `Repetition::new`.

## There is no measurable benefit

Worth stating plainly, since the July note predicted a "micro-alloc win". A/B against the previous build, rebuilt each way:

| workload | before | after |
|---|---|---|
| rfc3986 URI (cold, 3 runs) | 66.1 / 64.9 / 65.0 µs | 62.9 / 64.2 / 67.3 µs |
| rfc5322 mailbox (cold, 3 runs) | 362.1 / 343.0 / 348.7 µs | 335.5 / 349.4 / 353.4 µs |
| 400 `word 1*SP` pairs, repetition-heavy | 2.227 / 2.230 / 2.202 ms | 2.262 / 2.205 / 2.209 ms |

Overlapping ranges in every case, including the workload built specifically to stress the path. For `min = 1` the discarded allocation is one `Arc` clone and a one-element `Vec`, which does not register against the parsing work at each position.

## Why keep it

- **Parity.** Both backends now have the same structure here. One hoisted and one not is harder to reason about than either, and anyone reading the Python fix and looking for its counterpart will now find it.
- The allocation was pure waste, however small.

If you would rather not carry the churn for no measured gain, this is an easy one to drop — the reasoning is recorded either way.

## Also

Untangles a comment block in the same function that had been copy-pasted at the wrong indentation, duplicating the poisoned-mutex note in the middle of an expression.

## Verification

54 Rust tests, 1,392 (Rust) / 1,391 (Python), 2,469 fuzz, 800 differential cases with zero divergences, clippy clean; the concurrency and exclusion checks from the preceding PRs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
