### PR TITLE
Store Repetition matches pre-sorted so memo hits do not re-sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* The pure-Python `Repetition` stores its match list already sorted, so a memo
+  hit iterates it directly instead of copying and re-sorting a list that cannot
+  have changed.  A cold `rfc5322` mailbox parse takes ~1,700 such hits and is
+  about 5% faster as a result (median 5720 -> 5413 us).  Grammars that do not
+  backtrack are unaffected -- they get no memo hits at all -- so the other
+  benchmark workloads are unchanged.  Yield order is identical, verified by
+  fingerprinting the full ordered match sequence over 600 parses before and
+  after.  The Rust engine already worked this way.
+
 * The Rust engine builds a repetition's mandatory-prefix parser once, at
   construction, rather than rebuilding it on every cache miss.  `1*X` is the most
   common repetition in any grammar, and each miss allocated a `Vec` plus a

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -391,7 +391,11 @@ class Repetition:
                     cached_matchset.start,
                     *cached_matchset.args,
                 )
-            yield from next_longest(cached_matchset)
+            # Already longest-first: the list is sorted once, before it
+            # goes into the memo, rather than on every hit.  A cold
+            # rfc5322 parse takes ~1,700 hits, each of which used to
+            # pay a list copy and a sort of a list that never changes.
+            yield from cached_matchset
             return
 
         # De-duplicate by `Match.start` (i.e. by end position) rather
@@ -453,8 +457,14 @@ class Repetition:
             else:
                 break
 
+        # Sort in place, once, so both this yield and every later hit
+        # can iterate the stored list directly.  Same comparison and
+        # same stable sort `next_longest` applied, so the order is
+        # unchanged -- it just happens once instead of per hit.
+        if len(match_list) > 1:
+            match_list.sort(key=lambda match: match.start, reverse=True)
         memo[cache_key] = match_list
-        yield from next_longest(match_list)
+        yield from match_list
 
     def __str__(self):
         return f"Repetition({self.repeat}, {self.element})"


### PR DESCRIPTION
C5 from the July cache analysis — the last of its per-hit items.

`Repetition` stored its match list in discovery order, so every memo hit paid `next_longest`: a list copy plus a descending sort of a list that cannot have changed since it was stored. Sorting once before storing lets the storing yield and every later hit iterate the list directly.

## Re-measured, because the original number no longer applied

July quoted 4–7%, but measured on *warm* parses — cross-call cache hits, which stopped existing when memoisation became per-parse. The benefit is proportional to memo hits, and those are now strictly intra-parse:

| workload | memo hits / misses | before | after |
|---|---|---|---|
| rfc5322 mailbox | 1709 / 440 (**79.5%**) | 5720 µs | **5413 µs** |
| rfc3986 URI | 0 / 126 | — | unchanged |
| rfc7230 request-line | 0 / 18 | — | unchanged |
| rfc9051 astring | 0 / 1 | — | unchanged |

Medians of 7 samples each; the mailbox distributions don't overlap (new 5384–5495, old 5654–5798). So: a real ~5% win on grammars that backtrack, and nothing at all on grammars that don't — exactly what the hit counts predict, and worth knowing before anyone expects it to speed up URI parsing.

## Order is unchanged

Same key, same stable sort, applied once instead of per hit. Verified rather than argued: I fingerprinted the full ordered match sequence — start offset and matched text for every yielded match — over 600 mutated parses across six grammars, and the hash is identical before and after (`4cec76ea95b2d077`).

## Note

The Rust engine already sorted once before caching (`repetition.rs:152`) and returned the stored list directly on a hit, so this closes a gap between the backends rather than opening one.

## Verification

1,392 tests (Rust) / 1,391 (Python), 2,469 + 3,550 fuzz tests, 800 differential cases with zero divergences, ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
