### PR TITLE
Drop Match's hash memo; compare values, not hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+* `Match` no longer memoises its hash, and `Match.__eq__` compares values rather
+  than hashes.  Nothing in the parser hashes or compares a `Match` -- both
+  `Repetition` and `Rule.lparse` deduplicate by end offset -- so the cached slot
+  cost eight bytes on every match built, a few thousand per parse, to speed up
+  an operation the library never performs.  It also could not be invalidated:
+  `nodes` is a plain mutable list, so the memo went stale as soon as a caller
+  touched it.  `Match` is now 48 bytes rather than 56.
+
+  Comparing hashes meant two matches whose hashes collided compared equal;
+  `__eq__` now compares the text directly, which is the one place that has to be
+  exact.  Equality semantics are unchanged otherwise: matches are equal when
+  they consumed the same text and ended at the same offset, whatever node
+  structure produced it.  Hashing a `Match` repeatedly is ~4x slower without the
+  memo; parse times are unaffected.
+
 * The pure-Python `Repetition` stores its match list already sorted, so a memo
   hit iterates it directly instead of copying and re-sorting a list that cannot
   have changed.  A cold `rfc5322` mailbox parse takes ~1,700 such hits and is

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -17,40 +17,44 @@ Nodes = list["Node"]
 
 
 class Match:
-    __slots__ = ("_hash", "nodes", "start")
+    """A span of consumed source, identified by its text and end offset.
+
+    Two matches are equal when they consumed the same text and ended at
+    the same offset, whatever node structure produced it -- an ambiguous
+    grammar can reach the same span more than one way, and the parser
+    treats those as one result.
+    """
+
+    __slots__ = ("nodes", "start")
 
     def __init__(self, nodes: Nodes, start: int):
         self.nodes = nodes
         self.start = start
 
+    def _value(self) -> str:
+        return "".join(node.value for node in self.nodes)
+
     def __hash__(self) -> int:
-        # Cache the hash on first access.  Match objects participate
-        # in `set` operations inside Repetition / Rule.lparse where
-        # they're hashed repeatedly; without caching, every hash
-        # call rebuilds the concatenated value string by walking
-        # every descendant node.
-        try:
-            return self._hash
-        except AttributeError:
-            value = "".join(n.value for n in self.nodes)
-            h = hash((value, self.start))
-            self._hash = h
-            return h
+        # Not memoised.  Nothing in the parser hashes a `Match` -- both
+        # `Repetition` and `Rule.lparse` deduplicate by end offset -- so a
+        # cached slot would cost eight bytes on every match built (a few
+        # thousand per parse) to speed up an operation the library never
+        # performs.  It also could not be invalidated: `nodes` is a plain
+        # mutable list, so a memo went stale the moment a caller touched it.
+        return hash((self._value(), self.start))
 
     def __str__(self):
-        return (
-            f"Match(value={''.join(n.value for n in self.nodes)}, start={self.start})"
-        )
+        return f"Match(value={self._value()}, start={self.start})"
 
     def __eq__(self, __o: object) -> bool:
         if not isinstance(__o, self.__class__):
             return False
-        # Fast inequality short-circuit before the value-building
-        # hash comparison — different end positions can never be
-        # equal under our value-and-start semantics anyway.
-        if self.start != __o.start:
-            return False
-        return hash(self) == hash(__o)
+        # Compare the values, not their hashes.  Hash equality is only
+        # evidence of equality; two matches that collided would have
+        # compared equal, and `__eq__` is the one place that has to be
+        # exact.  `start` differs far more often than the text does, so
+        # checking it first usually avoids building either string.
+        return self.start == __o.start and self._value() == __o._value()
 
 
 MatchSet = set[Match]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -48,6 +48,76 @@ def test_next_longest():
     ]
 
 
+# ---------------------------------------------------------------------------
+# Match equality and hashing are used by callers, not by the parser -- both
+# Repetition and Rule.lparse deduplicate by end offset -- so nothing else in
+# the suite would notice these regressing.
+# ---------------------------------------------------------------------------
+
+
+def test_match_equality_is_by_value_and_end_offset():
+    ab = Match([cast(Node, LiteralNode("ab", 0, 2))], 2)
+    a_b = Match(
+        [cast(Node, LiteralNode("a", 0, 1)), cast(Node, LiteralNode("b", 1, 1))], 2
+    )
+    # Same text, same end: equal whatever node structure produced it.  An
+    # ambiguous grammar can reach one span several ways and the parser treats
+    # those as a single result.
+    assert ab == a_b
+    assert hash(ab) == hash(a_b)
+
+    # Same text, different end position.
+    assert ab != Match([cast(Node, LiteralNode("ab", 0, 2))], 3)
+    # Different text, same end position.
+    assert ab != Match([cast(Node, LiteralNode("xy", 0, 2))], 2)
+
+
+@pytest.mark.skipif(
+    __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
+    reason="Forcing a hash collision needs a subclass, and the Rust Match "
+    "pyclass cannot be subclassed.  The dispatch shim rebinds Match inside "
+    "_parser_python too, so the pure-Python class is unreachable here.",
+)
+def test_match_equality_does_not_rely_on_hash_equality():
+    # `__eq__` compares the values themselves.  Hash equality is only
+    # evidence of equality, so two matches that collided must still compare
+    # unequal.
+    class CollidingMatch(Match):
+        __slots__ = ()
+
+        def __hash__(self) -> int:
+            return 0
+
+    left = CollidingMatch([cast(Node, LiteralNode("a", 0, 1))], 1)
+    right = CollidingMatch([cast(Node, LiteralNode("b", 0, 1))], 1)
+    assert hash(left) == hash(right)
+    assert left != right
+
+
+def test_match_is_usable_in_a_set():
+    ab = Match([cast(Node, LiteralNode("ab", 0, 2))], 2)
+    same = Match(
+        [cast(Node, LiteralNode("a", 0, 1)), cast(Node, LiteralNode("b", 1, 1))], 2
+    )
+    other = Match([cast(Node, LiteralNode("ab", 0, 2))], 3)
+    assert len({ab, same, other}) == 2
+
+
+@pytest.mark.skipif(
+    __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND == "rust",
+    reason="The Rust Match hands back a fresh `nodes` list on each access, so "
+    "mutating it never reaches the match; the stale-memo question this pins "
+    "is specific to the pure-Python class, whose `nodes` is the live list.",
+)
+def test_match_hash_tracks_mutation():
+    # No memo, so a hash cannot go stale: `nodes` is the live list and a
+    # caller who edits it gets a hash for what the match now holds.
+    match = Match([cast(Node, LiteralNode("a", 0, 1))], 1)
+    before = hash(match)
+    match.nodes.append(cast(Node, LiteralNode("b", 1, 1)))
+    assert hash(match) != before
+
+
 def test_match_str():
     match = Match([], 0)
     assert str(match)


### PR DESCRIPTION
Two adjacent audit items on the same four lines of surface: **C11** (the dead hash memo) and **M1** (`__eq__` comparing hashes).

## C11 — the memo was dead for the parser, not for callers

Measured on current code: **zero** `__hash__` calls during a parse of any of the four benchmark grammars, while those same parses build 281–5,860 `Match` objects each. Both `Repetition` and `Rule.lparse` deduplicate by end offset, so nothing in the library ever hashes a match. The slot cost eight bytes apiece to accelerate an operation the parser never performs — and it could not be invalidated, since `nodes` is a plain mutable list, which is latent bug **L9**.

`Match` is now 48 bytes rather than 56.

## M1 — equality compared hashes

`__eq__` returned `hash(self) == hash(other)`, so two matches whose hashes collided compared equal. It now compares the text. Hash equality is only *evidence* of equality, and `__eq__` is the one place that has to be exact. `start` differs far more often than the text does, so it is still checked first and usually avoids building either string.

Semantics are otherwise unchanged: matches are equal when they consumed the same text and ended at the same offset, whatever node structure produced it — an ambiguous grammar reaching one span several ways is a single result, which is exactly what dedup-by-end-offset relies on.

## Honest about the trade

**This is not a speed change.** Parse times are unchanged in both directions:

| | master | this branch |
|---|---|---|
| rfc7230 request-line | 302.9 µs | 298.7 µs |
| rfc3986 URI | 933.6 µs | 961.3 µs |
| rfc5322 mailbox | 5238.3 µs | 5406.9 µs |
| rfc9051 astring | 72.1 µs | 72.7 µs |

And hashing a `Match` repeatedly is **~4× slower** without the memo (57.5 → 219.3 ns). What the change buys is smaller match objects, exact equality, and one fewer latent bug; what it costs falls on an operation no code in this repository performs.

I flagged this trade before implementing rather than after — if you would rather keep the memo, reverting is a small diff.

## Tests

Four tests pin the contract, because nothing else in the suite would notice it regressing. Two are pure-Python only, for reasons worth recording: the Rust `Match` pyclass cannot be subclassed (needed to force a collision), and it hands back a fresh `nodes` list on each access, so mutating it never reaches the match. The dispatch shim rebinds `Match` inside `_parser_python` as well, so the pure-Python class is genuinely unreachable when the extension is active.

## Verification

1,395 (Python) / 1,394 (Rust) tests, 2,469 + 3,550 fuzz, 800 differential cases with zero divergences, ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
