### PR TITLE
Document the Rust rule registry, and warn off clear_bridge()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@
   the case-insensitive lookup of *rule names*, which continues to use full
   folding on both backends.
 
+* Document the Rust engine's rule registry and how it grows in a long-running
+  process: 40 entries after `import abnf`, 1,176 with all bundled grammars
+  loaded, and one more per rule created at runtime, at roughly 1.6 KiB each.
+  A fixed cost for the ordinary import-once case; it accumulates only for
+  processes that build grammars per request or in a loop.  The pure-Python
+  `Rule._obj_map` grows the same way, so this is not specific to the Rust
+  backend.  The note also warns against `abnf_rust._ext.clear_bridge()`, a
+  private diagnostic that silently breaks any grammar defined after it runs
+  (https://github.com/declaresub/abnf/issues/187).
+
 * `NodeVisitor` computes its `visit_*` dispatch table once per class instead of
   rebuilding it from `dir(self)` on every instantiation.  `dir()` walks the whole
   MRO and sorts the result, which is a lot of work to repeat for an answer that

--- a/docs/how-to/use-the-rust-backend.md
+++ b/docs/how-to/use-the-rust-backend.md
@@ -48,6 +48,39 @@ choice when:
   generator-based, and trivially traceable;
 - `ABNF_NO_RUST=1` is convenient for a comparison.
 
+## Memory in a long-running process
+
+The engine keeps a registry mapping each Python `Rule` to its compiled
+counterpart. Entries are added when a rule is defined and are never removed, so
+the registry grows with the number of rules a process has ever created:
+
+| | entries |
+|---|---|
+| `import abnf` (the RFC 5234 core rules) | 40 |
+| plus all 32 bundled grammar modules | 1,176 |
+| plus 2,000 dynamically created grammars | 3,176 |
+
+At roughly 1.6 KiB per entry, the 2,000 dynamic grammars above cost about 3 MiB.
+
+For the ordinary case — importing grammar modules once at startup — this is a
+fixed cost and nothing to think about. It only accumulates if you build grammars
+at runtime: calling `Rule.create` on freshly-defined `Rule` subclasses in a loop,
+say, or per request. Note the pure-Python `Rule._obj_map` grows the same way and
+is not reclaimed either, so this is not specific to the Rust backend.
+
+```{warning}
+`abnf_rust._ext` exposes `clear_bridge()`, which empties the registry. It is a
+private diagnostic, not a supported knob, and calling it is **not safe**: the
+40 baseline entries are the core rules, so any grammar defined *after* a clear
+gets a fresh, empty handle for `ALPHA`, `DIGIT` and friends and silently fails
+to parse input it should accept.
+
+Grammars that were already fully built keep working — they hold their compiled
+handles directly — but redefining one of their rules after a clear also silently
+loses the change. There is currently no supported way to reclaim this memory --
+see [issue #187](https://github.com/declaresub/abnf/issues/187).
+```
+
 ## Build it for development
 
 To build and install the extension against your dev virtualenv (driving


### PR DESCRIPTION
C14 in the audit notes was "document `clear_bridge()` as an operator knob next to `max_cache_size`". Investigating it showed both halves of that were wrong, so this documents something different.

## `clear_bridge()` is neither public nor safe

**Not public:** it lives in `abnf_rust._ext`, is absent from `abnf_rust.__all__`, and has exactly one caller — a test.

**Not safe:** the 40 entries present after `import abnf` are the RFC 5234 core rules. Clearing them orphans the handles that later grammars reference:

```python
import abnf.parser
from abnf_rust._ext import clear_bridge

clear_bridge()
from abnf.grammars import rfc7230
rfc7230.Rule("request-line").parse_all("GET /x HTTP/1.1\r\n")
# ParseError -- valid input, rejected
```

Redefining a rule after a clear is silently lost too: the redefinition populates a fresh handle while existing trees keep the old one. Filed as **#187** with reproducers and options.

Advertising it in the configuration reference, as the audit note suggested, would have pointed users at a function that silently corrupts their grammars.

## What is worth documenting

The thing that prompted the question: the registry grows with every rule ever defined and is never reclaimed.

| | entries |
|---|---|
| `import abnf` (core rules) | 40 |
| plus all 32 bundled grammars | 1,176 |
| plus 2,000 dynamic grammars | 3,176 |

At ~1.6 KiB per entry, those 2,000 dynamic grammars cost about 3 MiB. A fixed cost for the ordinary import-once case; it accumulates only for processes that build grammars per request or in a loop. The pure-Python `Rule._obj_map` grows the same way and keeps every `Rule` alive, so the note says so rather than implying this is a Rust-backend tax.

New section in the Rust backend how-to with those figures and a warning box pointing at #187, plus a changelog entry. Docs build clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
