### PR TITLE
Fold case over US-ASCII only in literal matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+* **Behaviour change.**  Case-insensitive literal matching now folds case over
+  US-ASCII only, per RFC 5234 §2.3, which fixes the character set for literals
+  as US-ASCII.  Previously both backends folded the full Unicode range
+  (`str.casefold()` in Python, the `caseless` crate in Rust), which accepted
+  input outside the character set the grammar was written in: `%x212A` (KELVIN
+  SIGN) matched a `"k"` in a literal and `%x017F` (LATIN SMALL LETTER LONG S)
+  matched an `"s"`, so RFC 7230 accepted `compre\u017f\u017f` as a
+  transfer-coding.  Against a peer folding only ASCII, that is a parser
+  differential.  ASCII folding is also length-preserving, which removes a
+  position dependence: `Literal("ss", case_sensitive=False)` matched a lone
+  `'ß'` but not the `'ß'` in `'ßx'`.  Literals containing non-ASCII characters
+  still match themselves exactly; case-sensitive matching is unaffected, as is
+  the case-insensitive lookup of *rule names*, which continues to use full
+  folding on both backends.
+
 * `NodeVisitor` computes its `visit_*` dispatch table once per class instead of
   rebuilding it from `dir(self)` on every instantiation.  `dir()` walks the whole
   MRO and sorts the result, which is a lot of work to repeat for an answer that

--- a/docs/explanation/what-abnf-parses.md
+++ b/docs/explanation/what-abnf-parses.md
@@ -77,6 +77,31 @@ containing one raises `ValueError`; both messages say so and point at
 [issue #173](https://github.com/declaresub/abnf/issues/173).
 ```
 
+## Case-insensitivity is ASCII-only
+
+A quoted string in a grammar is case-insensitive by default — `"chunked"`
+matches `Chunked` — and RFC 5234 §2.3 fixes the character set for those
+literals as US-ASCII. `abnf` folds case over US-ASCII and nothing else, so
+matching stays inside the character set the grammar is written in:
+
+```python
+Rule("transfer-coding").parse_all("CHUNKED")        # matches
+Rule("transfer-coding").parse_all("chun\u212aed")   # KELVIN SIGN: no match
+```
+
+Full Unicode case folding — Python's `str.casefold()`, which is what `abnf`
+used before 2.7.0 — would match both, because `'\u212a'.casefold() == 'k'`.
+That over-accepts against an ASCII grammar, and it disagrees with peers that
+fold only ASCII, which is where protocol parsers get their differentials.
+
+Folding only ASCII is also length-preserving, so a literal always consumes
+exactly as many code points as it has. Under full folding it did not:
+`'ß'.casefold()` is `'ss'`, so `"ss"` matched a lone `'ß'` but not the `'ß'` in
+`'ßx'`, because the comparison folds a fixed-width window of the source.
+
+A literal containing non-ASCII characters still matches itself exactly; folding
+leaves those code points alone rather than rejecting them.
+
 ## Why there is no bytes API
 
 A `bytes` entry point would buy no capability — latin-1 already gives exact

--- a/packages/abnf-rust/rust/core/src/casefold.rs
+++ b/packages/abnf-rust/rust/core/src/casefold.rs
@@ -1,11 +1,23 @@
-//! Unicode case-folding helpers.
+//! Case-folding helpers.
 //!
-//! Matches Python's `str.casefold()` semantics via the `caseless`
-//! crate.  An ASCII fast-path avoids allocation for the overwhelmingly
-//! common case where neither the pattern nor the candidate contains a
-//! non-ASCII code point.
+//! Two different questions, deliberately kept apart:
+//!
+//! * [`ascii_fold`] folds literals, over US-ASCII only.  RFC 5234 §2.3
+//!   makes literals case-insensitive and says their character set is
+//!   US-ASCII, so nothing outside ASCII takes part.  It is also
+//!   length-preserving, which full folding is not.
+//! * [`casefold`] matches Python's `str.casefold()` via the `caseless`
+//!   crate, and is used for *rule names*, where both backends have
+//!   always agreed on full folding.
 
 use caseless::Caseless;
+
+/// Fold `s` over US-ASCII only: `A-Z` map to `a-z`, everything else is
+/// left exactly as it is.  Length-preserving, so a folded candidate has
+/// the same length as the source region it came from.
+pub fn ascii_fold(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
 
 /// Returns `s.casefold()` as a new `String`.  ASCII-only input takes a
 /// fast path that just lowercases ASCII bytes.

--- a/packages/abnf-rust/rust/core/src/literal.rs
+++ b/packages/abnf-rust/rust/core/src/literal.rs
@@ -11,16 +11,18 @@
 //! Mirrors `abnf.parser.Literal._lparse_value` /
 //! `_lparse_range` (`src/abnf/_parser_python.py:326-353`).
 //!
-//! ASCII fast paths are taken whenever both the pattern (and the
-//! range bounds) are pure ASCII; that covers essentially every
-//! real-world ABNF grammar and skips the UTF-8 decoder on the hot
-//! match loop.
+//! ASCII fast paths are taken whenever the pattern (or the range
+//! bounds) are pure ASCII; that covers essentially every real-world
+//! ABNF grammar and skips the UTF-8 decoder on the hot match loop.
+//! Case-insensitive matching folds over US-ASCII only, per RFC 5234
+//! §2.3, so it is length-preserving and needs no escape hatch for
+//! candidates that are not themselves ASCII.
 
 use std::sync::Arc;
 
 use smallvec::smallvec;
 
-use crate::casefold::casefold;
+use crate::casefold::ascii_fold;
 use crate::error::ParseError;
 use crate::matcher::Match;
 use crate::node::{LiteralNode, NodeKind};
@@ -65,7 +67,7 @@ impl Literal {
         let pattern: Arc<str> = if case_sensitive {
             value.clone()
         } else {
-            casefold(&value).into()
+            ascii_fold(&value).into()
         };
         let value_chars = value.chars().count();
         let is_ascii = value.is_ascii() && pattern.is_ascii();
@@ -168,54 +170,41 @@ impl Literal {
                     return Err(self.parse_error(start));
                 }
                 if *is_ascii {
-                    // Fast path: byte-level comparison.  Pattern
-                    // and value are both ASCII, so
-                    // `value_chars == pattern.len()` and we can
-                    // slice the source by byte.  Non-ASCII bytes in
-                    // the source fail the byte compare naturally
-                    // (a UTF-8 continuation byte is >= 0x80 while
-                    // every pattern byte is < 0x80).
+                    // Fast path: byte-level comparison.  Pattern and
+                    // value are both ASCII, so `value_chars ==
+                    // pattern.len()` and we can slice the source by
+                    // byte.  Non-ASCII bytes in the source fail the
+                    // byte compare naturally: every pattern byte is
+                    // < 0x80, and ASCII folding leaves a non-ASCII
+                    // byte alone, so no such byte can ever compare
+                    // equal.
                     //
-                    // Exception: in case-insensitive mode, some
-                    // non-ASCII codepoints casefold to an ASCII
-                    // multi-character sequence (e.g. 'ß' → 'ss',
-                    // 'ﬃ' → 'ffi').  Python's `Literal('ss',
-                    // case_sensitive=False)` matches a source of 'ß';
-                    // the byte-level fast path would incorrectly
-                    // reject it.  Fall through to the slow path
-                    // whenever the candidate region contains any
-                    // non-ASCII byte, where the full casefold can
-                    // express the expansion.
+                    // Folding over ASCII is length-preserving, so an
+                    // ASCII pattern always consumes exactly
+                    // `pattern.len()` source bytes.  (Under the full
+                    // Unicode folding used before, it was not: 'ß'
+                    // folded to "ss", so a 2-byte pattern could match
+                    // a 1-char source and this path had to defer to
+                    // the char-based one whenever the candidate held
+                    // a non-ASCII byte.)
                     let source_bytes = source.as_bytes();
                     let pattern_bytes = pattern.as_bytes();
                     let plen = pattern_bytes.len();
-                    if start + plen <= source_bytes.len() {
-                        let candidate = &source_bytes[start..start + plen];
-                        let candidate_is_ascii =
-                            candidate.iter().all(|b| *b < 128);
-                        if self.case_sensitive || candidate_is_ascii {
-                            return self.lparse_ascii_candidate(
-                                candidate,
-                                pattern_bytes,
-                                start,
-                            );
-                        }
-                        // Non-ASCII candidate in case-insensitive
-                        // mode: fall through to the slow path below.
-                    } else if self.case_sensitive {
-                        // Case-sensitive can never extend past EOF.
+                    if start + plen > source_bytes.len() {
                         return Err(self.parse_error(start));
                     }
-                    // Case-insensitive: even if the byte-slice would
-                    // run past EOF, the slow path needs to consider
-                    // shorter casefold-equivalent candidates (Python's
-                    // `source[start:start+N]` is permissive).
+                    return self.lparse_ascii_candidate(
+                        &source_bytes[start..start + plen],
+                        pattern_bytes,
+                        start,
+                    );
                 }
-                // Slow path: char-based.  Permissive about taken
-                // count when case-insensitive, since casefold can
-                // expand a short candidate into a pattern-length
-                // sequence (e.g. 'ß' → 'ss' satisfies a 2-char pattern
-                // from a 1-char source).
+                // Slow path: char-based, reached only for a
+                // non-ASCII pattern -- which the ABNF grammar itself
+                // cannot produce, since `char-val` is ASCII, but the
+                // Python `Literal` constructor can.  ASCII folding
+                // preserves char count, so a candidate shorter than
+                // the pattern can never match either way.
                 let remaining = source
                     .get(start..)
                     .ok_or_else(|| self.parse_error(start))?;
@@ -229,14 +218,14 @@ impl Literal {
                     taken += 1;
                     byte_end = i + ch.len_utf8();
                 }
-                if self.case_sensitive && taken < *value_chars {
+                if taken < *value_chars {
                     return Err(self.parse_error(start));
                 }
                 let candidate = &remaining[..byte_end];
                 let matches = if self.case_sensitive {
                     candidate == value.as_ref()
                 } else {
-                    casefold(candidate) == pattern.as_ref()
+                    ascii_fold(candidate) == pattern.as_ref()
                 };
                 if matches {
                     let matched: Arc<str> = Arc::from(candidate);

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -15,6 +15,33 @@ from .typing import Protocol, runtime_checkable
 Source = str
 Nodes = list["Node"]
 
+#: Folds the 26 ASCII uppercase letters and nothing else.
+_ASCII_FOLD_TABLE = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"
+)
+
+
+def _ascii_fold(value: str) -> str:
+    """Case-fold over US-ASCII only.
+
+    RFC 5234 §2.3 makes literals case-insensitive and says the character set
+    for them is US-ASCII, so case-insensitivity is defined over ASCII and
+    nothing else.  `str.casefold()`, used here previously, is full Unicode:
+    it matched a source of `'\u017f'` (long s) against `"s"`, `'\u212a'`
+    (Kelvin sign) against `"k"`, and `'ß'` against `"ss"` -- input a grammar
+    written in ASCII should reject.
+
+    Folding only ASCII also makes the operation length-preserving, which
+    Unicode folding is not.  The old behaviour therefore depended on
+    position: `"ss"` matched a lone `'ß'`, but `"ss" "x"` rejected `'ßx'`,
+    because the comparison folds a fixed-width window of the source.
+
+    Fast path via `str.lower`, which for an ASCII string *is* the ASCII
+    fold; CPython flags ASCII-ness on the object, so the test is free.
+    """
+
+    return value.lower() if value.isascii() else value.translate(_ASCII_FOLD_TABLE)
+
 
 class Match:
     """A span of consumed source, identified by its text and end offset.
@@ -526,7 +553,7 @@ class Literal:
         self.value = value
         self.case_sensitive = case_sensitive
         self.pattern = (
-            value if isinstance(value, tuple) or case_sensitive else value.casefold()
+            value if isinstance(value, tuple) or case_sensitive else _ascii_fold(value)
         )
 
         self.lparse = (
@@ -551,7 +578,7 @@ class Literal:
         # is handled correctly.
         if start < len(source):
             src = source[start : start + len(self.value)]
-            match = src if self.case_sensitive else src.casefold()
+            match = src if self.case_sensitive else _ascii_fold(src)
             if match == self.pattern:
                 yield Match(
                     [typing.cast(Node, LiteralNode(src, start, len(src)))],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -603,7 +603,10 @@ def test_173_pure_python_handles_surrogates():
         pass
 
     SurrogatePythonGrammar.create("s = 1*%x00-10FFFF")
-    assert SurrogatePythonGrammar("s").parse_all(_SURROGATE_SOURCE).value == _SURROGATE_SOURCE
+    assert (
+        SurrogatePythonGrammar("s").parse_all(_SURROGATE_SOURCE).value
+        == _SURROGATE_SOURCE
+    )
 
 
 def test_option_str():
@@ -991,45 +994,89 @@ def test_h4_parse_error_start_is_codepoint_on_non_ascii():
 
 
 # ---------------------------------------------------------------------------
-# H3 regression: case-insensitive Literal must honour Unicode casefold
-# expansion.  Python's `str.casefold()` maps some non-ASCII characters to
-# multi-character ASCII sequences (most famously 'ß' → 'ss', 'ﬃ' → 'ffi').
-# Per the pure-Python reference, `Literal('ss', case_sensitive=False)`
-# matches a source consisting of 'ß'.  The Rust backend's ASCII fast path
-# missed this case (byte-level compare against pattern 'ss' against source
-# bytes 0xc3 0x9f fails) and silently raised `ParseError`.
+# X3: case-insensitive matching folds over US-ASCII only.  RFC 5234 §2.3
+# makes literals case-insensitive and fixes their character set as
+# US-ASCII, so case-insensitivity is defined over ASCII and nothing else.
+#
+# Until 2.7.0 both backends used full Unicode folding (Python's
+# `str.casefold()`, the `caseless` crate in Rust), which over-accepted:
+# an ASCII grammar matched '\u017f' (long s) against "s" and '\u212a'
+# (Kelvin sign) against "k", so e.g. RFC 7230 accepted 'compre\u017f\u017f'
+# as a transfer-coding.  Against a peer that folds only ASCII, that is a
+# parser differential.
+#
+# Unicode folding is also not length-preserving, which made matching
+# position-dependent: Literal("ss") matched a lone 'ß' but not the 'ß' in
+# "ßx", because the comparison folds a fixed-width window of the source.
+# ASCII folding removes both problems.
 # ---------------------------------------------------------------------------
 
 
-def test_h3_casefold_expansion_ss_matches_eszett():
-    """'ß'.casefold() == 'ss' — Literal('ss') should match 'ß' under
-    case-insensitive comparison."""
-    parser = Literal("ss", case_sensitive=False)
-    match = next(parser.lparse("ß", 0))
-    assert match.start == 1  # consumed one code point of source
+@pytest.mark.parametrize(
+    "pattern, source",
+    [
+        ("ss", "ß"),  # 'ß'.casefold() == 'ss'
+        ("SS", "ß"),
+        ("ffi", "\ufb03"),  # 'ﬃ'.casefold() == 'ffi'
+        ("s", "\u017f"),  # LATIN SMALL LETTER LONG S
+        ("k", "\u212a"),  # KELVIN SIGN
+        ("K", "\u212a"),
+    ],
+)
+def test_x3_case_insensitive_does_not_fold_non_ascii(pattern, source):
+    """Non-ASCII source must not match an ASCII pattern, in either
+    direction of case."""
+    parser = Literal(pattern, case_sensitive=False)
+    with pytest.raises(ParseError):
+        next(parser.lparse(source, 0))
+
+
+def test_x3_case_insensitive_still_folds_ascii():
+    """The folding that RFC 5234 does require is unaffected."""
+    parser = Literal("Chunked", case_sensitive=False)
+    match = next(parser.lparse("cHUNKED", 0))
+    assert match.start == 7
     # The matched LiteralNode preserves the source's original spelling.
-    assert match.nodes[0].value == "ß"
+    assert match.nodes[0].value == "cHUNKED"
 
 
-def test_h3_casefold_expansion_ffi_ligature():
-    """'ﬃ'.casefold() == 'ffi'."""
-    parser = Literal("ffi", case_sensitive=False)
-    match = next(parser.lparse("ﬃ", 0))
-    assert match.start == 1
-    assert match.nodes[0].value == "ﬃ"
+def test_x3_ascii_fold_is_length_preserving():
+    """A pattern always consumes exactly as many code points as it has,
+    so a match no longer depends on what follows it."""
+    parser = Literal("ss", case_sensitive=False)
+    match = next(parser.lparse("SSx", 0))
+    assert match.start == 2
+    with pytest.raises(ParseError):
+        next(parser.lparse("ßx", 0))
 
 
-def test_h3_casefold_expansion_uppercase_ss_matches_eszett():
-    """'SS'.casefold() == 'ss' and 'ß'.casefold() == 'ss'."""
-    parser = Literal("SS", case_sensitive=False)
-    match = next(parser.lparse("ß", 0))
-    assert match.start == 1
+def test_x3_non_ascii_literal_matches_itself():
+    """Folding leaves non-ASCII alone rather than rejecting it: a
+    non-ASCII literal still matches an exact copy of itself."""
+    parser = Literal("Straße", case_sensitive=False)
+    match = next(parser.lparse("STRAßE", 0))
+    assert match.start == 6
+    # ...but the case-mapped spelling of the non-ASCII part does not.
+    with pytest.raises(ParseError):
+        next(parser.lparse("STRASSE", 0))
 
 
-def test_h3_case_sensitive_does_not_expand():
-    """In case-sensitive mode, 'ß' should NOT match 'ss' — casefold
-    expansion is disabled by definition."""
+def test_x3_grammar_rejects_non_ascii_transfer_coding():
+    """The end-to-end shape of the differential: an ASCII grammar must
+    not accept a non-ASCII homoglyph of one of its keywords."""
+    from abnf.grammars import rfc7230
+
+    assert rfc7230.Rule("transfer-coding").parse_all("chunked")
+    for source in ("chun\u212aed", "compre\u017f\u017f"):
+        with pytest.raises(ParseError):
+            rfc7230.Rule("transfer-coding").parse_all(source)
+
+
+def test_x3_case_sensitive_does_not_fold():
+    """Case-sensitive matching is unchanged: no folding of any kind."""
     parser = Literal("ss", case_sensitive=True)
+    with pytest.raises(ParseError):
+        next(parser.lparse("SS", 0))
     with pytest.raises(ParseError):
         next(parser.lparse("ß", 0))
 


### PR DESCRIPTION
RFC 5234 §2.3 makes literals case-insensitive and fixes their character set as US-ASCII, so case-insensitivity is defined over ASCII and nothing else. Both backends folded the full Unicode range — `str.casefold()` in Python, the `caseless` crate in Rust.

## Why this matters

Eleven non-ASCII code points fold onto pure-ASCII text, so an ASCII grammar accepted homoglyphs of its own keywords:

```python
rfc7230.Rule("transfer-coding").parse_all("chunKed")     # KELVIN SIGN  -> accepted
rfc7230.Rule("transfer-coding").parse_all("compreſſ")  # LONG S     -> accepted
```

Against a peer that folds only ASCII, that is a parser differential — the classic shape behind request smuggling and filter bypass. All 11 are now rejected on both backends.

Full folding is also not length-preserving, which made matching position-dependent: `Literal("ss", case_sensitive=False)` matched a lone `'ß'` but not the `'ß'` in `"ßx"`, because the comparison folds a fixed-width window of the source. ASCII folding removes that.

## Scope

| | before | after |
|---|---|---|
| literal, case-insensitive | full Unicode fold | US-ASCII fold |
| literal, case-sensitive | no folding | unchanged |
| non-ASCII literal vs itself | matches | matches |
| rule-name lookup | full Unicode fold | unchanged |

Rule names stay on full folding on both backends: they are ASCII by spec, so the two already agree, and changing it would widen the change for no gain. `caseless` therefore stays as a dependency.

The Rust literal fast path loses its escape hatch for candidates containing non-ASCII bytes — it existed only to express casefold expansion (`'ß'` → `"ss"`). An ASCII pattern now always consumes exactly `pattern.len()` bytes.

## Behaviour change

This reverses the four `test_h3_*` tests, which asserted the expansion. They are replaced by X3 tests covering both directions plus the end-to-end RFC 7230 shape.

## Verification

- 1,407 Python / 1,406 Rust tests, 2,469 fuzz, 54 Rust tests
- A sweep of every cased code point — 24,444 pattern × source comparisons across both case modes — with zero divergence between backends
- The 43-case differential suite: only the known surrogate limitation (#173)
- Benchmarks: ~1–4% slower on pure Python (the fold goes 62 → 80 ns; an exact-hit fast path was tried and did not pay, since failed comparisons dominate under backtracking). Rust unchanged within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
