### PR TITLE
Remove clear_bridge(), which could not do its job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+* Remove `abnf_rust._ext.clear_bridge()`, a private diagnostic that emptied the
+  Rust engine's rule registry.  It could not do its job and broke correctness in
+  the attempt: a rule's compiled tree embeds the handles of the rules it
+  references, so clearing the registry frees very little, while every grammar
+  defined afterwards gets fresh empty handles for `ALPHA`, `DIGIT` and friends
+  and silently rejects valid input.  Redefining a rule after a clear was
+  silently lost, too.  The registry's growth is documented instead, with the
+  measured cost on both backends, and the note now points at the lever that
+  actually works -- caching the `Rule` subclass for a grammar rather than
+  rebuilding it (https://github.com/declaresub/abnf/issues/187).
+
 * **Behaviour change.**  Case-insensitive literal matching now folds case over
   US-ASCII only, per RFC 5234 §2.3, which fixes the character set for literals
   as US-ASCII.  Previously both backends folded the full Unicode range

--- a/docs/how-to/use-the-rust-backend.md
+++ b/docs/how-to/use-the-rust-backend.md
@@ -60,7 +60,11 @@ the registry grows with the number of rules a process has ever created:
 | plus all 32 bundled grammar modules | 1,176 |
 | plus 2,000 dynamically created grammars | 3,176 |
 
-At roughly 1.6 KiB per entry, the 2,000 dynamic grammars above cost about 3 MiB.
+Each entry is about 1.6 KiB, but the entry is not the whole cost: it points at a
+compiled parser tree, and the Python `Rule` and its own tree stay alive too.
+Measured end to end over 2,000 dynamically created three-rule grammars (6,040
+rules), resident memory grows by 13.3 MiB on the pure-Python backend and 35.7
+MiB on the Rust backend — 2.2 and 6.1 KiB per rule respectively.
 
 For the ordinary case — importing grammar modules once at startup — this is a
 fixed cost and nothing to think about. It only accumulates if you build grammars
@@ -68,17 +72,28 @@ at runtime: calling `Rule.create` on freshly-defined `Rule` subclasses in a loop
 say, or per request. Note the pure-Python `Rule._obj_map` grows the same way and
 is not reclaimed either, so this is not specific to the Rust backend.
 
-```{warning}
-`abnf_rust._ext` exposes `clear_bridge()`, which empties the registry. It is a
-private diagnostic, not a supported knob, and calling it is **not safe**: the
-40 baseline entries are the core rules, so any grammar defined *after* a clear
-gets a fresh, empty handle for `ALPHA`, `DIGIT` and friends and silently fails
-to parse input it should accept.
+```{note}
+There is no way to reclaim this memory, and that is deliberate. A private
+`clear_bridge()` used to empty the registry; it was removed in 2.7.0 because it
+could not do the job and broke correctness in the attempt.
 
-Grammars that were already fully built keep working — they hold their compiled
-handles directly — but redefining one of their rules after a clear also silently
-loses the change. There is currently no supported way to reclaim this memory --
-see [issue #187](https://github.com/declaresub/abnf/issues/187).
+Clearing frees very little: a rule's compiled tree embeds the handles of the
+rules it references, so those trees stay alive through the grammar that uses
+them, and the Python side retains its share regardless. What it does do is
+desynchronise the two sides. The 40 baseline entries are the core rules, so any
+grammar defined *after* a clear gets a fresh, empty handle for `ALPHA`, `DIGIT`
+and friends, and silently fails to parse input it should accept; redefining a
+rule after a clear silently loses the change, because live trees still hold the
+old handle.
+
+If you build grammars at runtime and the growth matters, the lever is on the
+Python side. Growth tracks *distinct rules ever created*, not parses: parsing
+2,000 times through an already-built grammar costs nothing measurable. So cache
+the `Rule` subclass for a given grammar and reuse it, rather than defining a
+fresh subclass each time you need it. `Rule._obj_map` is keyed by
+`(class, name)`, so redefining a rule on a class you already have replaces the
+entry instead of adding one — though it also raises `GrammarWarning` each time,
+which is a good sign you meant to reuse the built grammar instead.
 ```
 
 ## Build it for development

--- a/packages/abnf-rust/rust/pyo3/src/bridge.rs
+++ b/packages/abnf-rust/rust/pyo3/src/bridge.rs
@@ -11,7 +11,23 @@
 //!
 //! The key is the Python object's pointer.  `Rule._obj_map` keeps
 //! every Rule alive for the lifetime of its class, so pointers are
-//! stable.
+//! stable -- and that immortality is load-bearing, not incidental.
+//! Were a `Rule` ever collected, the allocator could hand its address
+//! to a new `Rule`, which would then silently inherit the dead rule's
+//! compiled tree from this map.
+//!
+//! There is deliberately no operation to clear or prune the registry.
+//! A `clear_bridge()` existed until issue #187: because a rule's
+//! compiled tree embeds the `Arc<NamedRule>` handles of the rules it
+//! references, dropping the map does not free those trees -- it only
+//! desynchronises the two sides.  Rules defined afterwards look up
+//! `ALPHA`, `DIGIT` and friends, find nothing, and build fresh empty
+//! handles, so the grammar rejects valid input; and redefining an
+//! existing rule writes to an orphan while live trees keep the old
+//! handle.  Nor would clearing reclaim much: the Python side retains
+//! roughly a third of the per-rule cost in `_obj_map` regardless.
+//! Registry growth is a function of rules created, and is documented
+//! in `docs/how-to/use-the-rust-backend.md`.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -78,24 +94,6 @@ pub fn set_exclude_for(
     };
     handle.set_exclude(excluded);
     Ok(())
-}
-
-/// Drop every entry in the bridge registry.
-///
-/// The registry holds one `Arc<NamedRule>` (plus its parser tree) for
-/// every Python `Rule` instance the engine has ever seen.  Long-lived
-/// processes that load grammars dynamically (e.g. via repeated
-/// `Rule.create(...)` on freshly-constructed classes) will accumulate
-/// entries indefinitely, since Python's class-level `_obj_map` keeps
-/// rule classes alive for the duration of the process.
-///
-/// Exposed as `abnf_rust._ext.clear_bridge()` so callers with that
-/// usage pattern can periodically drop the Rust-side shadow state.
-/// Subsequent parses re-populate the registry lazily.
-#[pyfunction]
-pub fn clear_bridge() {
-    let mut guard = BRIDGE.lock().unwrap_or_else(|e| e.into_inner());
-    guard.clear();
 }
 
 /// Current size of the bridge registry.  Primarily useful in tests

--- a/packages/abnf-rust/rust/pyo3/src/lib.rs
+++ b/packages/abnf-rust/rust/pyo3/src/lib.rs
@@ -50,7 +50,6 @@ fn _ext(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(bootstrap::bootstrap, m)?)?;
     m.add_function(wrap_pyfunction!(hooks::set_definition_hook, m)?)?;
     m.add_function(wrap_pyfunction!(hooks::set_exclude_hook, m)?)?;
-    m.add_function(wrap_pyfunction!(bridge::clear_bridge, m)?)?;
     m.add_function(wrap_pyfunction!(bridge::bridge_size, m)?)?;
 
     Ok(())

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1092,14 +1092,15 @@ def test_x3_case_sensitive_does_not_fold():
 
 
 # ---------------------------------------------------------------------------
-# M7 regression: the Rust bridge registry (Python `Rule` id →
-# `Arc<NamedRule>`) grows monotonically as new rules are created.  For
-# long-lived processes that load grammars dynamically, that's a memory
-# leak — Python's class-level `_obj_map` already keeps every Rule
-# alive, but the Rust shadow adds a second `Arc` to the parser tree.
-# `clear_bridge()` lets callers drop the shadow state when they know
-# they're done with a batch of dynamic grammars; subsequent parses
-# repopulate the bridge lazily.
+# M7 / #187: the Rust bridge registry (Python `Rule` id -> `Arc<NamedRule>`)
+# grows as rules are created, and there is no way to reclaim it.  That is
+# by design on both sides: `Rule._obj_map` is a permanent symbol table, so
+# the Python backend retains every rule too -- about a third of the
+# per-rule cost.  A `clear_bridge()` used to exist; it could not free the
+# compiled trees (rules embed each other's handles directly) and it broke
+# every grammar defined afterwards, so it was removed.  Its absence is
+# part of the contract: the bridge keys on the Python object's address,
+# which is only sound because `_obj_map` makes those addresses immortal.
 # ---------------------------------------------------------------------------
 
 
@@ -1107,25 +1108,29 @@ def test_x3_case_sensitive_does_not_fold():
     __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND != "rust",
     reason="The bridge registry only exists under the Rust backend.",
 )
-def test_m7_clear_bridge_releases_entries():
-    from abnf_rust._ext import bridge_size, clear_bridge  # type: ignore[import-not-found]
+def test_187_bridge_has_no_clearing_operation():
+    import abnf_rust._ext as ext  # type: ignore[import-not-found]
 
-    # Start from a known state.
-    clear_bridge()
-    assert bridge_size() == 0
+    assert not hasattr(ext, "clear_bridge"), (
+        "clear_bridge() breaks every grammar defined after it runs (#187); "
+        "it must not come back without also solving Rule._obj_map"
+    )
 
-    # Define a grammar; rule construction populates the bridge as
-    # `_set_definition_hook` fires.
-    class _M7Grammar(Rule):
+
+@pytest.mark.skipif(
+    __import__("abnf.parser", fromlist=["_BACKEND"])._BACKEND != "rust",
+    reason="The bridge registry only exists under the Rust backend.",
+)
+def test_187_bridge_grows_with_rules_created():
+    from abnf_rust._ext import bridge_size  # type: ignore[import-not-found]
+
+    before = bridge_size()
+
+    class _BridgeGrowth(Rule):
         pass
 
-    _M7Grammar.create('a = "x"')
-    populated = bridge_size()
-    assert populated > 0, "expected the bridge to gain at least one entry"
-
-    # The headline fix: clear_bridge drops everything.
-    clear_bridge()
-    assert bridge_size() == 0
+    _BridgeGrowth.create('a = "x"')
+    assert bridge_size() > before, "expected the bridge to gain an entry"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #187.

`abnf_rust._ext.clear_bridge()` emptied the registry mapping Python `Rule` objects to their compiled counterparts. It was private, had one test caller, and was the only mechanism offered for reclaiming registry memory — but it reclaimed almost nothing and broke correctness in the attempt.

## Why removal rather than a fix

A rule's compiled tree embeds the `Arc<NamedRule>` handles of the rules it references, so those trees stay alive through the grammars that use them. Clearing the map frees very little; what it does do is desynchronise the two sides:

- The 40 baseline entries are the RFC 5234 core rules, so any grammar defined **after** a clear gets fresh empty handles for `ALPHA`, `DIGIT` and friends and silently rejects valid input.
- Redefining a rule after a clear is silently lost, because live trees keep the old handle.
- The docstring's claim that "subsequent parses re-populate the registry lazily" was false. Parses never touch the registry; only definition writes do.

The test that exercised it was itself a landmine — it called `clear_bridge()` mid-suite, so any later test defining a grammar over core rules would have failed. The suite passed on ordering alone; a two-test reproduction confirms `1*ALPHA` fails after a clear.

## The growth it was meant to address

Not Rust-specific, and not a leak: `Rule._obj_map` is a permanent symbol table, so **both** backends retain every rule ever created. Measured over 2,000 dynamically created three-rule grammars (6,040 rules):

| backend | RSS growth | per rule |
|---|---|---|
| pure Python | +13.3 MiB | 2.25 KiB |
| Rust | +35.7 MiB | 6.05 KiB |

Growth tracks *rules created*, not parses — 2,000 parses through an already-built grammar cost 0.03 MiB. The how-to now carries these numbers and the lever that actually works: cache the `Rule` subclass for a grammar instead of rebuilding it (43 entries and +3.4 MiB instead of +35.7).

## Why the bridge can't just hold weak references

It keys on the Python object's **address**, which is sound only because `_obj_map` makes those addresses immortal. If a `Rule` were ever collected, the allocator could hand its address to a new `Rule`, which would silently inherit the dead rule's compiled tree — I confirmed the reuse happens in practice when a rule is evicted. So solving the growth means solving `_obj_map` first, and that is public-ish surface (`Rule.get`, `Rule.rules`). Recorded in the module docs so a future reader doesn't reintroduce a clearing operation.

## Verification

3,876 tests on Rust / 4,957 on Python, plus fuzz; Rust crate tests and clippy clean. Two new tests: one asserting the function stays gone, one pinning the growth behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
