### PR TITLE
Export Parser from the top-level package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Export `Parser` from the top-level `abnf` package.  It is the protocol the
+  combinators satisfy, and it is useful for annotating code that accepts or
+  returns a parser -- which meant reaching into `abnf.parser` for it.  Being a
+  `Protocol`, it describes a shape rather than a base class: `Rule`, the
+  built-in combinators (including the Rust-backed ones) and a parser you write
+  yourself all satisfy it without inheriting anything
+  (https://github.com/declaresub/abnf/issues/17).
+
 * The Rust engine represents the source as **code points** rather than as
   `&str`, which fixes the last behavioural difference between the two backends.
   It previously worked in `char` and `&str` -- Unicode *scalar values* and

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3,12 +3,13 @@
 The public API is exported from the top-level `abnf` package:
 
 ```python
-from abnf import Rule, Node, LiteralNode, NodeVisitor, ParseError, GrammarError
+from abnf import Rule, Node, LiteralNode, NodeVisitor, Parser, ParseError, GrammarError
 ```
 
 The parser combinator primitives (`Alternation`, `Concatenation`, `Repetition`,
 `Option`, `Literal`, `Prose`) are internal and not part of the public API; see
-{doc}`../explanation/architecture` for how they fit together.
+{doc}`../explanation/architecture` for how they fit together.  `Parser` is the
+protocol they satisfy, exported for type hints rather than for instantiation.
 
 ## Rule
 
@@ -37,6 +38,29 @@ The parser combinator primitives (`Alternation`, `Concatenation`, `Repetition`,
 .. autoclass:: abnf.NodeVisitor
    :members:
 ```
+
+## Parser
+
+```{eval-rst}
+.. autoclass:: abnf.Parser
+   :members:
+```
+
+A [protocol](https://docs.python.org/3/library/typing.html#typing.Protocol), not
+a base class: anything with a compatible `lparse` satisfies it, including the
+combinators, `Rule`, and a parser you write yourself.  Use it to annotate code
+that accepts or returns a parser.
+
+```python
+from abnf import Parser
+
+
+def wrap(inner: Parser) -> Parser:
+    ...
+```
+
+It is `runtime_checkable`, so `isinstance(obj, Parser)` works too — bearing in
+mind that this checks only for the presence of `lparse`, not its signature.
 
 ## Exceptions
 

--- a/src/abnf/__init__.py
+++ b/src/abnf/__init__.py
@@ -9,6 +9,7 @@ from abnf.parser import (
     Node,
     NodeVisitor,
     ParseError,
+    Parser,
     Rule,
 )
 
@@ -19,6 +20,7 @@ __all__ = [
     "Node",
     "NodeVisitor",
     "ParseError",
+    "Parser",
     "Rule",
     "__version__",
 ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1433,3 +1433,42 @@ def test_170_deep_nesting_on_a_small_stack_is_catchable_not_fatal():
         f"expected a caught exception, got: stdout={result.stdout!r}, "
         f"stderr={result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Public API surface (issue #17).  `Parser` is the protocol the combinators
+# satisfy, and it is useful as a type hint in code that accepts or returns a
+# parser -- so it belongs at the top level next to the other public names.
+# ---------------------------------------------------------------------------
+
+
+def test_17_parser_is_exported_from_the_top_level():
+    import abnf
+
+    assert abnf.Parser is _parser_python.Parser
+    assert "Parser" in abnf.__all__
+
+
+def test_17_public_names_are_all_importable():
+    """Everything `__all__` promises must actually be there, whichever
+    backend is active."""
+    import abnf
+
+    missing = [name for name in abnf.__all__ if not hasattr(abnf, name)]
+    assert not missing
+
+
+def test_17_parser_recognises_combinators_and_user_parsers():
+    """It is `runtime_checkable`, and structural -- so a Rust-backed
+    combinator satisfies it without inheriting anything."""
+    import abnf
+
+    class MyParser:
+        def lparse(self, source, start):
+            yield Match([], start)
+
+    assert isinstance(Literal("a"), abnf.Parser)
+    assert isinstance(Concatenation(Literal("a")), abnf.Parser)
+    assert isinstance(Rule("some-rule"), abnf.Parser)
+    assert isinstance(MyParser(), abnf.Parser)
+    assert not isinstance(object(), abnf.Parser)


### PR DESCRIPTION
Closes #17.

`Parser` is the protocol every combinator satisfies. It was already public in `abnf.parser` (and in that module's `__all__`), but not at the top level, so annotating code meant reaching one level deeper than the rest of the public API.

```python
from abnf import Parser


def wrap(inner: Parser) -> Parser:
    ...
```

## What this does and does not add

It exports a **type hint**, not a new inheritance point. `Parser` is a `typing.Protocol`, so it describes a shape — `Rule`, the built-in combinators, and a user's own `lparse` implementation all satisfy it already, without inheriting anything. That matters for the Rust backend in particular: its combinators are pyclasses that inherit nothing from Python, and they satisfy the protocol structurally.

Verified on both backends:

| | satisfies `Parser` |
|---|---|
| `Literal("a")` (Rust-backed pyclass) | yes |
| `Concatenation(...)`, `Rule(...)` | yes |
| a hand-written class with `lparse` | yes |
| `object()` | no |

It is also `runtime_checkable`, so `isinstance(obj, Parser)` works — but that checks only for the *presence* of `lparse`, not its signature. The reference docs say so, so nobody reads more into an isinstance check than it can bear.

I checked it behaves as a hint under pyright, not just at runtime: annotating parameters and return types with `Parser` type-checks clean against the library combinators, and a user class whose `lparse` has the wrong return type is correctly rejected.

## Tests

New tests pin the export, assert every name in `__all__` actually resolves (on whichever backend is active — nothing covered that before), and cover structural recognition of a combinator, a `Rule`, and a hand-written parser.

## Note

A user *implementing* the protocol also needs `Source` and `Matches` to write the signature, and those are still only in `abnf.parser`. Left alone as out of scope here — say the word if you want them promoted too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
