### PR TITLE
Pin RFC 3986 path behaviour, and warn about empty alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+* Tests for RFC 3986's `path` rule, and a documented caveat about first-match
+  alternation.  `path` lists `path-abempty` first, and that alternative matches
+  the empty string, which looks like it should swallow every input.  It does
+  not under the default longest-match semantics, and the grammar is left as the
+  RFC writes it; the tests pin that, along with the cases where `path-empty` is
+  genuinely reached (`hier-part` and `relative-part` of an empty path, as in
+  `mailto:`).  Under `first_match_alternation = True` the concern is real --
+  `path` then matches nothing at all -- so the alternation docs now warn that an
+  alternative which can match empty makes everything after it unreachable, which
+  is why first match is not a drop-in switch for a grammar transcribed from an
+  RFC (https://github.com/declaresub/abnf/issues/24).
+
 * Export `Parser` from the top-level `abnf` package.  It is the protocol the
   combinators satisfy, and it is useful for annotating code that accepts or
   returns a parser -- which meant reaching into `abnf.parser` for it.  Being a

--- a/docs/explanation/alternation-semantics.md
+++ b/docs/explanation/alternation-semantics.md
@@ -31,3 +31,27 @@ Choosing longest match is what makes abnf faithful to RFC grammars out of the bo
 choosing first match lets you model PEG-like grammars that depend on ordered
 choice. The trade-off in cost is discussed in {doc}`backtracking-and-caching` and
 {doc}`rust-backend-performance`.
+
+## Watch out for alternatives that can match nothing
+
+Under first match, an alternative that can match the empty string wins as soon as
+it is tried — and it is tried in declaration order, not in order of how much it
+consumes. Any alternative after it becomes unreachable.
+
+RFC grammars are written this way regularly, because their authors assumed
+longest match. RFC 3986 is a good example:
+
+```text
+path        = path-abempty / path-absolute / path-noscheme / path-rootless / path-empty
+path-abempty = *( "/" segment )          ; matches "" quite happily
+```
+
+Under the default, `path` parses `a/b/c` as `path-noscheme` and consumes all of
+it. Set `first_match_alternation = True` and the same rule returns an empty
+match, because `path-abempty` is listed first and succeeds immediately
+([issue #24](https://github.com/declaresub/abnf/issues/24)).
+
+So first match is not a drop-in speedup for a grammar transcribed from an RFC.
+Enable it for a grammar written with ordered choice in mind, or per rule where
+you have checked the alternatives — `abnf.grammars.rfc3986` does the latter for
+`host`, where the RFC's own order is the intended one.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,6 +15,19 @@ class MyGrammar(Rule):
     first_match_alternation = True
 ```
 
+It can also be set per rule:
+
+```python
+rfc3986.Rule("host").first_match_alternation = True
+```
+
+```{warning}
+Under first match, an alternative that can match the empty string makes every
+alternative after it unreachable. Grammars transcribed from RFCs often rely on
+longest match and list such an alternative first, so this is not a drop-in
+switch — see {doc}`../explanation/alternation-semantics`.
+```
+
 See {doc}`../explanation/alternation-semantics` for why this is configurable.
 
 ## `ParseCache.max_cache_size` (deprecated)

--- a/tests/test_rfc3986.py
+++ b/tests/test_rfc3986.py
@@ -13,3 +13,51 @@ from abnf.grammars import rfc3986
 def test_IPv6address(src: str, value: str):
     ip6 = rfc3986.Rule('IPv6address')
     assert ip6.parse_all(src).value == value
+
+
+# Issue #24: `path` lists `path-abempty` first, and `path-abempty` is
+# `*( "/" segment )`, which matches the empty string -- so under first-match
+# alternation it would swallow every input.  Under the default (longest match)
+# it does not, and these tests pin that rather than reordering the grammar
+# away from the RFC's own text.
+@pytest.mark.parametrize(
+    'src, alternative',
+    [
+        ('/a/b/c', 'path-abempty'),
+        ('/', 'path-abempty'),
+        ('//x', 'path-abempty'),
+        ('', 'path-abempty'),
+        ('a/b/c', 'path-noscheme'),
+        ('a', 'path-noscheme'),
+        # ':' is a pchar but not a segment-nz-nc char, so path-noscheme stops
+        # at the colon and the longer path-rootless wins.
+        ('a:b/c', 'path-rootless'),
+        ('x%20y/z', 'path-noscheme'),
+    ],
+)
+def test_24_path_consumes_the_whole_input(src: str, alternative: str):
+    node = rfc3986.Rule('path').parse_all(src)
+    assert node.value == src
+    assert [child.name for child in node.children] == [alternative]
+
+
+@pytest.mark.parametrize(
+    'rule, src, alternative',
+    [
+        # path-empty is not dead: it is how an empty path is matched where
+        # path-abempty is not among the alternatives being tried.
+        ('hier-part', '', 'path-empty'),
+        ('relative-part', '', 'path-empty'),
+        ('hier-part', '/a/b', 'path-absolute'),
+        ('relative-part', 'a/b', 'path-noscheme'),
+    ],
+)
+def test_24_empty_and_relative_paths(rule: str, src: str, alternative: str):
+    node = rfc3986.Rule(rule).parse_all(src)
+    assert node.value == src
+    assert alternative in [child.name for child in node.children]
+
+
+@pytest.mark.parametrize('src', ['mailto:', 'urn:ietf:rfc:2648', 'http://example.com'])
+def test_24_uri_with_empty_or_rootless_path(src: str):
+    assert rfc3986.Rule('URI').parse_all(src).value == src


### PR DESCRIPTION
Closes #24.

The issue observed that `path` lists `path-abempty` first, and that `path-abempty = *( "/" segment )` matches the empty string — so it looks as though it must swallow every input. It does not, because alternation is longest-match by default:

| input | alternative chosen | consumed |
|---|---|---|
| `/a/b/c` | `path-abempty` | all |
| `a/b/c` | `path-noscheme` | all |
| `a:b/c` | `path-rootless` | all |
| `` (empty) | `path-abempty` | all |

The maintainer's reply asked for tests rather than a change, and that is what this is.

## The grammar is left as the RFC writes it

Reordering wouldn't merely be unnecessary — it would be a behaviour change. `/a/b` matches both `path-abempty` and `path-absolute` at the same length, and ties are broken by declaration order, so reordering would change which alternative wins and therefore the parse tree users already get.

## What the tests cover

- Every `path` alternative, including the tie cases
- `a:b/c` → `path-rootless`, because `:` is a `pchar` but not a `segment-nz-nc` char, so `path-noscheme` stops at the colon and the longer alternative wins
- The places `path-empty` is genuinely reached — `hier-part` / `relative-part` with an empty path, as in `mailto:`. It is not dead code, it is just unreachable *within `path`*
- Whole-URI cases: `mailto:`, `urn:ietf:rfc:2648`, `http://example.com`

The reporter's own follow-up finding is confirmed: no rule references bare `path`, so it exists for callers who want it directly.

## Where the concern is real

Under `first_match_alternation = True`, it happens exactly as described:

```python
r = rfc3986.Rule("path")
r.first_match_alternation = True
r.parse("a/b/c", 0)        # -> ('', 0)  — empty match
r.parse_all("a/b/c")       # -> ParseError at 0
```

An alternative that can match empty succeeds immediately and makes every later alternative unreachable. Grammars transcribed from RFCs assume longest match and do this routinely, so first match is not a drop-in switch — as this very module knows, enabling it only for `host`. That is now documented in the alternation explanation and flagged in the configuration reference, rather than left to be rediscovered.

Tests pass on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
