### PR TITLE
Make first_match_alternation reach nested alternations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+* `first_match_alternation` now reaches alternations nested inside a group or
+  repetition, whether set grammar-wide or on a single rule.  Both forms were
+  broken: as a class attribute it shadowed the property of the same name and
+  nothing read it, so it did nothing at all; set on a rule it flipped only that
+  rule's top-level `Alternation`, so `a = "a" ( "b" / "bc" )` and
+  `iuserinfo = *( iunreserved / pct-encoded / sub-delims / ":" )` could not be
+  configured -- the assignment was silently dropped, and reading the attribute
+  back returned `False`.  The alternations are now recorded as each rule is
+  built, which is the only approach open to both backends: the Rust
+  combinators expose no children, so the tree cannot be walked afterwards
+  (https://github.com/declaresub/abnf/issues/53).
+
+  Two consequences worth noting.  A grammar that sets the class attribute
+  today gets first-match semantics it was asking for but not receiving --
+  `abnf.grammars.rfc3987` sets it on every rule, and its parse results are
+  unchanged, because its alternatives are disjoint on their first character.
+  And setting the flag on a rule with no alternation stays a no-op rather than
+  raising: the grammar is valid, the same flag set grammar-wide covers many
+  such rules, and a single-alternative rule collapses to its element, so
+  raising would make the call brittle under ordinary edits.  Setting it on an
+  undefined rule still raises `GrammarError`.
+
+  The attribute is a descriptor rather than a property, so that the documented
+  spelling type-checks: assigning a `bool` in a subclass body is an
+  incompatible override of a `property`, which pyright rejects in user code.
+
 * Tests for RFC 3986's `path` rule, and a documented caveat about first-match
   alternation.  `path` lists `path-abempty` first, and that alternative matches
   the empty string, which looks like it should swallow every input.  It does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,15 @@ Key classes:
 - `Alternation`, `Concatenation`, `Repetition`, `Option`, `Literal`, `Prose` — Internal parser combinator primitives (not part of public API).
 - `ABNFGrammarRule` / `ABNFGrammarNodeVisitor` — Bootstrapped parser for ABNF grammar syntax itself; converts parsed ABNF text into `Rule`-based parser objects.
 
-**Alternation behavior** is controlled by `Rule.first_match_alternation` (class attribute):
+**Alternation behavior** is controlled by `Rule.first_match_alternation`:
 - `False` (default): longest match wins; ties broken by declaration order
 - `True`: first match returned immediately
+
+Set as a class attribute it is the grammar-wide default, read as each rule is
+built and applied to every `Alternation` including nested ones; set on a rule it
+flips the alternations recorded for that rule. Nested alternations are recorded
+at build time because the Rust combinators expose no children, so the parser
+tree cannot be walked from Python.
 
 ### Grammar Modules (`src/abnf/grammars/`)
 

--- a/docs/explanation/alternation-semantics.md
+++ b/docs/explanation/alternation-semantics.md
@@ -19,6 +19,25 @@ class FirstMatchGrammar(Rule):
     first_match_alternation = True
 ```
 
+Set on the class, it applies to every alternation in the grammar, including
+those nested inside a group or repetition — `a = "a" ( "b" / "bc" )` and
+`iuserinfo = *( iunreserved / pct-encoded / sub-delims / ":" )` are both
+covered. It is read as each rule is built, so set it in the class body, before
+the grammar is loaded.
+
+It can also be set on a single rule, which likewise reaches the alternations
+nested inside that rule:
+
+```python
+rfc3986.Rule("host").first_match_alternation = True
+```
+
+A per-rule setting covers that rule's own definition only. Rules it *references*
+keep their own setting — otherwise configuring one rule would silently change
+another. And a rule with no alternation at all has nothing to resolve, so
+setting the flag on it does nothing and the attribute continues to read
+`False`.
+
 ## Why it matters
 
 Consider `astring = 1*ASTRING-CHAR / string`. Under longest-match semantics, the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,11 +15,20 @@ class MyGrammar(Rule):
     first_match_alternation = True
 ```
 
-It can also be set per rule:
+Set in a class body it becomes the grammar's default, applied to every
+alternation built for it — including alternations nested inside a group or
+repetition, which a rule does not otherwise expose.
+
+It can also be set per rule, and reaches that rule's nested alternations too:
 
 ```python
 rfc3986.Rule("host").first_match_alternation = True
 ```
+
+A per-rule setting does not extend to rules that rule references — those are
+separate rules with their own setting. On a rule containing no alternation the
+setting is vacuous: it is not an error, and the attribute reads `False`.
+Setting it on an *undefined* rule raises `GrammarError`.
 
 ```{warning}
 Under first match, an alternative that can match the empty string makes every

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -612,6 +612,25 @@ class Prose:
 T = typing.TypeVar("T", bound="Rule")
 
 
+class _FirstMatchAlternation:
+    """Backs :attr:`Rule.first_match_alternation` for both class-level and
+    per-rule access.
+
+    Read on the class it reports the grammar-wide default; read on a rule it
+    reports that rule's alternations.  Written on a rule it flips them.
+    (Written in a *class body* it is replaced outright, which is what
+    ``Rule.__init_subclass__`` exists to undo.)
+    """
+
+    def __get__(self, instance: Rule | None, owner: type[Rule] | None = None) -> bool:
+        if instance is None:
+            return owner._first_match_default if owner is not None else False
+        return instance._get_first_match_alternation()
+
+    def __set__(self, instance: Rule, value: bool) -> None:
+        instance._set_first_match_alternation(value)
+
+
 class Rule:
     """A parser generated from an ABNF rule.
 
@@ -712,28 +731,87 @@ class Rule:
         typing.Callable[[Rule, Rule | None], None] | None
     ] = None
 
-    @property
-    def first_match_alternation(self) -> bool:
-        try:
-            definition = self.definition
-        except AttributeError:
-            return False
-        else:
-            return isinstance(definition, Alternation) and definition.first_match
+    #: Grammar-wide default for alternation semantics, applied to every
+    #: ``Alternation`` built for this class's rules -- including ones
+    #: nested inside a group or repetition, which is the whole point:
+    #: those are unreachable afterwards, since a rule exposes only its
+    #: top-level definition.  Written as ``first_match_alternation`` in
+    #: a subclass body; ``__init_subclass__`` moves it here so it does
+    #: not shadow the property of the same name.
+    _first_match_default: typing.ClassVar[bool] = False
 
-    @first_match_alternation.setter
-    def first_match_alternation(self, value: bool):
+    #: Alternations this rule's definition is built from, recorded at
+    #: grammar-build time.  ``None`` for a rule built directly from a
+    #: parser object, where there is nothing to record.
+    _alternations: tuple[Alternation, ...] | None = None
+
+    def __init_subclass__(cls, **kwargs: typing.Any) -> None:
+        super().__init_subclass__(**kwargs)
+        raw = cls.__dict__.get("first_match_alternation")
+        if isinstance(raw, bool):
+            cls._first_match_default = raw
+            # Restore the inherited property: a plain bool left in the
+            # class body would shadow it, so instances of this grammar
+            # could neither read nor set the flag per rule.  Deleting via
+            # the metaclass removes the class attribute; `del
+            # cls.first_match_alternation` would read as an attempt to
+            # delete the property itself, which has no deleter.
+            type.__delattr__(cls, "first_match_alternation")
+
+    def _alternation_parsers(self) -> tuple[Alternation, ...]:
+        """Every ``Alternation`` this rule's own definition is built
+        from, outermost first.
+
+        Recorded when the rule is built from ABNF text, because that is
+        the only moment the nested ones are in hand: the Rust backend's
+        combinators expose no children, so the tree cannot be walked
+        afterwards.  Rules constructed directly from a parser fall back
+        to the definition itself, which preserves the old behaviour for
+        hand-built rules.
+
+        Rules referenced by this one are deliberately not included --
+        they are separate rules, with their own setting.
+        """
+
+        recorded = getattr(self, "_alternations", None)
+        if recorded is not None:
+            return recorded
+        definition = getattr(self, "_definition", None)
+        return (definition,) if isinstance(definition, Alternation) else ()
+
+    def _get_first_match_alternation(self) -> bool:
+        """Whether alternation in this rule resolves to the first match.
+
+        ``False`` when the rule contains no alternation at all: there is
+        nothing to resolve, so there is nothing to report.
+        """
+
+        alternations = self._alternation_parsers()
+        return bool(alternations) and all(a.first_match for a in alternations)
+
+    def _set_first_match_alternation(self, value: bool) -> None:
         try:
-            definition = self.definition
+            _ = self.definition
         except AttributeError as exc:
             msg = f'Undefined rule "{self.name}"'
             raise GrammarError(msg) from exc
-        else:
-            if isinstance(definition, Alternation):
-                definition.first_match = value
-            else:
-                # skip.  Or should some exception be raised?
-                pass
+        for alternation in self._alternation_parsers():
+            alternation.first_match = value
+        # A rule with no alternation is not an error -- the same flag set
+        # grammar-wide covers plenty of such rules -- so setting it is
+        # simply vacuous, and the getter says so.
+
+    if typing.TYPE_CHECKING:
+        # Declared as a plain ``bool`` for type checkers.  At runtime it is
+        # the descriptor below, which serves both spellings of the same
+        # setting -- ``MyGrammar.first_match_alternation = True`` in a class
+        # body and ``rule.first_match_alternation = True`` on one rule.  A
+        # ``property`` cannot: assigning a bool in a subclass body is an
+        # incompatible override, so the documented spelling would not
+        # type-check for users.
+        first_match_alternation: bool
+    else:
+        first_match_alternation = _FirstMatchAlternation()
 
     def exclude_rule(self, rule: Rule) -> None:
         """
@@ -1593,6 +1671,10 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
 
     def __init__(self, rule_cls: type[Rule], *args: typing.Any, **kwargs: typing.Any):
         self.rule_cls = rule_cls
+        #: Alternations built for the rule currently being visited.
+        #: Kept because a nested one is otherwise unreachable once the
+        #: tree is assembled -- see ``Rule._alternation_parsers``.
+        self._alternations: list[Alternation] = []
         self.visit_char_val = CharValNodeVisitor()
         self.visit_num_val = NumValVisitor()
         # superclass init needs to happen here so that it will
@@ -1603,7 +1685,18 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
         """Creates an Alternation object from alternation node."""
         assert node.name == "alternation"
         args: list[Parser] = list(filter(NotNull, map(self.visit, node.children)))
-        return Alternation(*args) if len(args) > 1 else args[0]
+        if len(args) <= 1:
+            # A single alternative is not an alternation; ABNF allows
+            # writing one, and it collapses to the element itself.
+            return args[0]
+        return self._new_alternation(*args)
+
+    def _new_alternation(self, *args: Parser) -> Alternation:
+        """Build an `Alternation` with the grammar's semantics, and keep
+        hold of it so the rule can reach it later."""
+        alternation = Alternation(*args, first_match=self.rule_cls._first_match_default)
+        self._alternations.append(alternation)
+        return alternation
 
     def visit_concatenation(self, node: Node):
         """Creates a Concatention object from concatenation node."""
@@ -1689,6 +1782,10 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
         rule: Rule
         defined_as: str
         elements: Parser
+        # Collect the alternations built while visiting *this* rule; the
+        # unpacking below is what drives the lazy map, so the list is
+        # empty until then.
+        self._alternations = []
         rule, defined_as, elements = filter(NotNull, map(self.visit, node.children))
         # this assertion tells mypy that rule should actually be an object. Without, mypy
         # returns 'error: <nothing> has no attribute "definition"'
@@ -1718,9 +1815,15 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
                 GrammarWarning,
                 stacklevel=2,
             )
-        rule.definition = (
-            elements if defined_as == "=" else Alternation(rule.definition, elements)
-        )
+        if defined_as == "=":
+            rule.definition = elements
+            rule._alternations = tuple(self._alternations)
+        else:
+            # '=/' keeps the earlier definition as one arm, so its
+            # alternations stay live and stay configurable.
+            previous = rule._alternation_parsers()
+            rule.definition = self._new_alternation(rule.definition, elements)
+            rule._alternations = tuple(previous) + tuple(self._alternations)
         return rule
 
     def visit_rulelist(self, node: Node):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1472,3 +1472,132 @@ def test_17_parser_recognises_combinators_and_user_parsers():
     assert isinstance(Rule("some-rule"), abnf.Parser)
     assert isinstance(MyParser(), abnf.Parser)
     assert not isinstance(object(), abnf.Parser)
+
+
+# ---------------------------------------------------------------------------
+# first_match_alternation (issue #53).  Setting it reached only a rule's
+# top-level `Alternation`, so `a = "a" ( "b" / "bc" )` and
+# `iuserinfo = *( ... / ... )` could not be configured at all -- the setter
+# silently did nothing.  The grammar-wide class attribute did nothing either:
+# it shadowed the property, and nothing read it.
+#
+# Both now work, by recording the alternations as the grammar is built.  That
+# is the only approach available to both backends: the Rust combinators expose
+# no children, so the tree cannot be walked after the fact.
+# ---------------------------------------------------------------------------
+
+
+class _FirstMatch(Rule):
+    first_match_alternation = True
+
+
+_FirstMatch.create('top = "a" / "ab"')
+_FirstMatch.create('nested = *( "a" / "ab" )')
+_FirstMatch.create('grouped = "x" ( "b" / "bc" )')
+
+
+class _LongestMatch(Rule):
+    pass
+
+
+_LongestMatch.create('top = "a" / "ab"')
+_LongestMatch.create('nested = *( "a" / "ab" )')
+_LongestMatch.create('grouped = "x" ( "b" / "bc" )')
+_LongestMatch.create('plain = "b" "c"')
+_LongestMatch.create("ref = top")
+
+
+@pytest.mark.parametrize(
+    "rule, source, first, longest",
+    [
+        ("top", "ab", 1, 2),
+        # the cases that could not be configured before
+        ("nested", "abab", 1, 4),
+        ("grouped", "xbc", 2, 3),
+    ],
+)
+def test_53_class_attribute_reaches_nested_alternations(
+    rule: str, source: str, first: int, longest: int
+):
+    assert _FirstMatch(rule).parse(source, 0)[1] == first
+    assert _LongestMatch(rule).parse(source, 0)[1] == longest
+
+
+def test_53_class_attribute_does_not_shadow_the_property():
+    """A bool in the class body used to replace the property outright,
+    leaving the grammar's rules unable to read or set the flag."""
+    assert _FirstMatch("top").first_match_alternation is True
+    assert _LongestMatch("top").first_match_alternation is False
+
+
+def test_53_per_rule_setter_reaches_nested_alternations():
+    rule = _LongestMatch("grouped")
+    assert rule.first_match_alternation is False
+
+    rule.first_match_alternation = True
+    assert rule.first_match_alternation is True
+    assert _LongestMatch("grouped").parse("xbc", 0)[1] == 2
+
+    rule.first_match_alternation = False
+    assert rule.first_match_alternation is False
+    assert _LongestMatch("grouped").parse("xbc", 0)[1] == 3
+
+
+def test_53_per_rule_setter_does_not_leak_into_referenced_rules():
+    """`ref = top` references a separate rule, which keeps its own
+    setting -- otherwise one rule's configuration would mutate another's."""
+    _LongestMatch("ref").first_match_alternation = True
+    try:
+        assert _LongestMatch("top").parse("ab", 0)[1] == 2
+    finally:
+        _LongestMatch("ref").first_match_alternation = False
+
+
+def test_53_rule_without_alternation_is_vacuous_not_an_error():
+    """`plain = "b" "c"` has nothing to resolve.  The grammar is valid, and
+    the same flag set grammar-wide covers plenty of such rules, so setting
+    it is simply vacuous -- and the getter says so."""
+    rule = _LongestMatch("plain")
+    rule.first_match_alternation = True
+    assert rule.first_match_alternation is False
+    rule.first_match_alternation = False
+
+
+def test_53_undefined_rule_still_raises():
+    class _Undefined(Rule):
+        pass
+
+    with pytest.raises(GrammarError):
+        _Undefined("nope").first_match_alternation = True
+
+
+def test_53_incremental_definition_keeps_both_alternations_configurable():
+    """`=/` wraps the earlier definition as one arm; alternations from
+    both halves must stay reachable."""
+
+    class _Incremental(Rule):
+        pass
+
+    _Incremental.create('r = "x" ( "b" / "bc" )')
+    _Incremental.create('r =/ "y" ( "c" / "cd" )')
+
+    rule = _Incremental("r")
+    rule.first_match_alternation = True
+    assert rule.first_match_alternation is True
+    assert _Incremental("r").parse("xbc", 0)[1] == 2
+    assert _Incremental("r").parse("ycd", 0)[1] == 2
+
+
+def test_53_hand_built_rule_still_honours_a_top_level_alternation():
+    """A rule constructed from a parser object has no recorded
+    alternations; the definition itself is the fallback."""
+
+    class _HandBuilt(Rule):
+        pass
+
+    _HandBuilt("r", Alternation(Literal("a"), Literal("ab")))
+    rule = _HandBuilt("r")
+    assert rule.first_match_alternation is False
+    rule.first_match_alternation = True
+    assert rule.first_match_alternation is True
+    assert _HandBuilt("r").parse("ab", 0)[1] == 1


### PR DESCRIPTION
Closes #53.

Setting `first_match_alternation` reached only a rule's **top-level** `Alternation`, so a rule whose alternation sits inside a group or repetition could not be configured at all — the two shapes the issue names:

```abnf
a         = "a" ( "b" / "bc" )
iuserinfo = *( iunreserved / pct-encoded / sub-delims / ":" )
```

The assignment was silently dropped (the setter literally had `# skip.  Or should some exception be raised?`) and reading the attribute back returned `False`.

The grammar-wide spelling was broken more completely: `class G(Rule): first_match_alternation = True` **shadowed the property** of the same name, and nothing read it — so it did nothing whatsoever. That spelling is documented in three places, including `CLAUDE.md`.

## This is a regression, not a design gap

The original 2020 implementation passed the class's setting to every `Alternation` as the grammar was built, nested ones included:

```python
return Alternation(*args, first_match=self.rule_cls.first_match_alternation) if len(args) > 1 else args[0]
```

That argument was dropped when backtracking was implemented, and the class attribute became a property over the rule's definition. The visitor still carries `rule_cls` — only the argument was missing.

## Approach

Record the alternations as each rule is built, and have both spellings act on that record. **This is the only approach open to both backends**: the Rust combinators expose no children (`Alternation` has just `first_match`/`lparse`, `Repetition` just `lparse`), so the parse tree cannot be walked from Python afterwards. Flipping a recorded alternation does reach the Rust engine, because the pyclass wraps the same `Arc` embedded in the compiled tree — verified.

| | before | after |
|---|---|---|
| `top = "a" / "ab"` on `"ab"` | 1 consumed | 1 |
| `nested = *( "a" / "ab" )` on `"abab"` | 4 (ignored) | **1** |
| `grouped = "x" ( "b" / "bc" )` on `"xbc"` | 3 (ignored) | **2** |

Details: `=/` keeps the earlier definition as one arm, so alternations from both halves stay reachable. A rule built directly from a parser object has nothing recorded and falls back to its definition, preserving today's behaviour. A rule's setting covers its own definition only — rules it *references* keep theirs, or configuring one rule would silently mutate another.

The attribute is now a **descriptor** rather than a property. A property cannot serve both spellings: assigning a `bool` in a subclass body is an incompatible override, so the documented form did not type-check in user code — pyright rejects it. The descriptor also makes a class-level read report the grammar default instead of a property object.

## Deliberately not an error

Setting the flag on a rule with no alternation (`c = "b" "c"`) stays a no-op rather than raising. The grammar is valid; the same flag set grammar-wide covers many such rules; assigning `False` would otherwise have to raise too; and a single-alternative rule collapses to its element, so trimming `x = "a" / "b"` to `x = "a"` would make previously working configuration code start raising. The getter reports `False`, which is the honest answer. Setting it on an **undefined** rule still raises `GrammarError`.

## Effect on bundled grammars

`abnf.grammars.rfc3987` sets the flag on every rule, citing RFC 3987 §2.2 — and until now silently missed exactly the rules this issue names. Its parse results are **byte-identical** before and after across 14 IRIs and 4 sub-rule cases (its alternatives are disjoint on their first character), so it now gets the semantics it asked for without any change in what it accepts.

Benchmarks unchanged — this is grammar-build work, not parse work.

## On the `|` operator

Not implemented, and I'd argue against it: a dialect extension makes grammars unreadable by other ABNF tools (the reasoning that closed #3), and it would not have fixed either bug. Once the setting reaches nested alternations, the need it was reaching for is covered.

The issue's PS — that the `Rule` class methods are under-demonstrated — is untouched here and worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
