### PR TITLE
Correct release-version references and raise the abnf-rust floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Raise the `[rust]` extra's floor to `abnf-rust>=2.8`.  The two packages
+  release under one tag, and this release is one where they must agree on
+  behaviour rather than just on API: the engine moved to a code-point source
+  model, so surrogate handling and offset semantics come from the extension.
+  An older `abnf-rust` would still import and parse, and would silently
+  deliver the behaviour this version's own documentation says it does not.
+
 * `first_match_alternation` now reaches alternations nested inside a group or
   repetition, whether set grammar-wide or on a single rule.  Both forms were
   broken: as a class attribute it shadowed the property of the same name and

--- a/docs/explanation/what-abnf-parses.md
+++ b/docs/explanation/what-abnf-parses.md
@@ -71,7 +71,7 @@ is a property of the decode, not of the parser.
 Both backends handle them, and identically. The Rust engine used to work in
 `char` and `&str` — Unicode *scalar values* and well-formed UTF-8, neither of
 which can hold a surrogate — so a grammar naming one failed to load and input
-containing one failed to cross the FFI. Since 2.7.0 it indexes by code point
+containing one failed to cross the FFI. Since 2.8.0 it indexes by code point
 like the pure-Python backend, and both accept the whole domain
 ([issue #173](https://github.com/declaresub/abnf/issues/173)).
 
@@ -88,7 +88,7 @@ Rule("transfer-coding").parse_all("chun\u212aed")   # KELVIN SIGN: no match
 ```
 
 Full Unicode case folding — Python's `str.casefold()`, which is what `abnf`
-used before 2.7.0 — would match both, because `'\u212a'.casefold() == 'k'`.
+used before 2.8.0 — would match both, because `'\u212a'.casefold() == 'k'`.
 That over-accepts against an ASCII grammar, and it disagrees with peers that
 fold only ASCII, which is where protocol parsers get their differentials.
 

--- a/docs/how-to/use-the-rust-backend.md
+++ b/docs/how-to/use-the-rust-backend.md
@@ -74,7 +74,7 @@ is not reclaimed either, so this is not specific to the Rust backend.
 
 ```{note}
 There is no way to reclaim this memory, and that is deliberate. A private
-`clear_bridge()` used to empty the registry; it was removed in 2.7.0 because it
+`clear_bridge()` used to empty the registry; it was removed in 2.8.0 because it
 could not do the job and broke correctness in the attempt.
 
 Clearing frees very little: a rule's compiled tree embeds the handles of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,14 @@ rust = [
     # the same git tag.  Lower bound matches the current minor; upper
     # bound clamps to the next major so a future `abnf-rust` release
     # with a breaking change can't silently come in via the extra.
-    'abnf-rust>=2.5,<3',
+    #
+    # Raise this bound whenever the two packages have to agree on
+    # behaviour, not just on API.  2.8 is such a release: the engine
+    # moved to a code-point source model, so surrogate handling and
+    # offset semantics come from the extension.  An older `abnf-rust`
+    # would still import and parse, and would silently deliver the
+    # behaviour this version's own documentation says it does not.
+    'abnf-rust>=2.8,<3',
 ]
 # Documentation toolchain (Sphinx + MyST for Markdown prose + autodoc for the
 # API reference from docstrings).  Kept separate from `dev` so running the test

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1128,7 +1128,7 @@ def test_h4_parse_error_start_is_codepoint_on_non_ascii():
 # makes literals case-insensitive and fixes their character set as
 # US-ASCII, so case-insensitivity is defined over ASCII and nothing else.
 #
-# Until 2.7.0 both backends used full Unicode folding (Python's
+# Until 2.8.0 both backends used full Unicode folding (Python's
 # `str.casefold()`, the `caseless` crate in Rust), which over-accepted:
 # an ASCII grammar matched '\u017f' (long s) against "s" and '\u212a'
 # (Kelvin sign) against "k", so e.g. RFC 7230 accepted 'compre\u017f\u017f'


### PR DESCRIPTION
Release-prep corrections, found while checking which version the pending changes ship in.

## 2.7.0 is already released

Three doc references and one test comment named 2.7.0 as the version introducing the code-point model, ASCII-only case folding, and the removal of `clear_bridge()`. All of that is still unreleased; 2.7.0 is tagged and shipped. Corrected to 2.8.0:

- `docs/explanation/what-abnf-parses.md` (×2 — surrogates, case folding)
- `docs/how-to/use-the-rust-backend.md` (`clear_bridge()` removal)
- `tests/test_parser.py` (X3 section comment)

## The `[rust]` extra's floor had drifted

`abnf-rust>=2.5,<3`, with a comment saying the lower bound tracks the current minor — but `abnf` is at 2.7. Raised to `>=2.8,<3`, and it matters more than usual this time.

The two packages release under one git tag, so they are normally in step by construction. This release is one where they must agree on **behaviour**, not just API: after #173 the engine's source model is code points, so surrogate handling and offset semantics come from the extension. An older `abnf-rust` would still import and parse happily, and would silently deliver exactly the failures this version's documentation says are fixed.

The comment now states *when* to raise the bound, so the next person has a rule rather than a number to guess at.

## Not a problem

`packages/abnf-rust/Cargo.toml` hardcodes `version = "2.5.0"`, which looks stale but isn't: the release workflow rewrites it from the tag at build time, so both packages publish at the tag version.

## Why 2.8.0 and not 3.0.0

`Unreleased` contains two changes that alter behaviour for existing users — ASCII-only case folding, and `first_match_alternation` reaching nested alternations. Strict semver would call those breaking, but this project's precedent puts equivalent changes in minors: 2.7.0 *lowered* the recursion ceiling from ~1000 to ~180 levels, and 2.6.0 changed an exception type and what the CORS `Origin` grammar accepts. Both of this release's changes are corrections bringing the implementation in line with RFC 5234 §2.3 and with its own documentation, which is the same shape.

Worth a second opinion if you'd rather hold to strict semver — the fold change does reject previously-accepted input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
