### PR TITLE
Fix the release-blocking dependency floor, and guard it in CI

### DIFF
--- a/.github/workflows/abnf-tox.yml
+++ b/.github/workflows/abnf-tox.yml
@@ -127,3 +127,36 @@ jobs:
     - name: Run tests
       run: pytest --ignore=tests/fuzz --ignore=tests/benchmarks
 
+  # ----------------------------------------------------------------
+  # Release-dependency resolvability
+  # ----------------------------------------------------------------
+  #
+  # The release workflow resolves the runtime dependency closure to
+  # build the SBOM, and that resolution happens *before* anything is
+  # published.  So a dependency bound naming a version that is not on
+  # PyPI yet -- the one being released, say -- makes the release
+  # unbuildable, and nothing in the ordinary test matrix would notice:
+  # this is the only place the resolution is exercised outside a tag
+  # build.  Run the same command here, where it costs seconds and
+  # fails a PR instead of a release.
+
+  lockfile:
+    name: Release deps resolve
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Install uv
+      run: |
+        python3 -m pip install --user 'uv==0.11.8'
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: uv.lock agrees with pyproject.toml
+      run: uv lock --check
+
+    - name: Runtime dependency closure resolves
+      # The exact command the release workflow runs for the SBOM.
+      run: |
+        uv export --no-dev --extra rust --no-hashes --no-emit-project \
+          --format requirements-txt -o /dev/null

--- a/.github/workflows/abnf-tox.yml
+++ b/.github/workflows/abnf-tox.yml
@@ -146,6 +146,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Install uv
       run: |
@@ -157,6 +159,8 @@ jobs:
 
     - name: Runtime dependency closure resolves
       # The exact command the release workflow runs for the SBOM.
+      # Written to a real path, not /dev/null: uv writes a temp file
+      # beside the target and renames it, which /dev cannot host.
       run: |
         uv export --no-dev --extra rust --no-hashes --no-emit-project \
-          --format requirements-txt -o /dev/null
+          --format requirements-txt -o "$RUNNER_TEMP/requirements.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,12 +231,13 @@
   is why first match is not a drop-in switch for a grammar transcribed from an
   RFC (https://github.com/declaresub/abnf/issues/24).
 
-* Raise the `[rust]` extra's floor to `abnf-rust>=2.8`.  The two packages
-  release under one tag, and this release is one where they must agree on
-  behaviour rather than just on API: the engine moved to a code-point source
-  model, so surrogate handling and offset semantics come from the extension.
-  An older `abnf-rust` would still import and parse, and would silently
-  deliver the behaviour this version's own documentation says it does not.
+* Raise the `[rust]` extra's floor to `abnf-rust>=2.7`, and check in CI that
+  the runtime dependency closure still resolves.  The floor can only name a
+  version already on PyPI: the release workflow resolves this dependency to
+  build the SBOM, before anything is published, so naming the version being
+  released makes the release unbuildable.  Nothing outside a tag build
+  exercised that resolution, so CI now runs the same command on every pull
+  request, along with `uv lock --check`.
 
 ## 2.7.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,13 +70,12 @@ rust = [
     # bound clamps to the next major so a future `abnf-rust` release
     # with a breaking change can't silently come in via the extra.
     #
-    # Raise this bound whenever the two packages have to agree on
-    # behaviour, not just on API.  2.8 is such a release: the engine
-    # moved to a code-point source model, so surrogate handling and
-    # offset semantics come from the extension.  An older `abnf-rust`
-    # would still import and parse, and would silently deliver the
-    # behaviour this version's own documentation says it does not.
-    'abnf-rust>=2.8,<3',
+    # The floor can only name a version that is already on PyPI: the
+    # release workflow resolves this dependency (via `uv export`, for
+    # the SBOM) *before* publishing, so naming the version being
+    # released makes the release unbuildable.  Raise it in the cycle
+    # after the one that introduces the requirement, never in it.
+    'abnf-rust>=2.7,<3',
 ]
 # Documentation toolchain (Sphinx + MyST for Markdown prose + autodoc for the
 # API reference from docstrings).  Kept separate from `dev` so running the test

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ rust = [
 
 [package.metadata]
 requires-dist = [
-    { name = "abnf-rust", marker = "extra == 'rust'", specifier = ">=2.5,<3" },
+    { name = "abnf-rust", marker = "extra == 'rust'", specifier = ">=2.7,<3" },
     { name = "check-manifest", marker = "extra == 'dev'", specifier = "==0.51" },
     { name = "furo", marker = "extra == 'docs'", specifier = "==2025.12.19" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.165.2" },
@@ -53,15 +53,15 @@ provides-extras = ["dev", "rust", "docs"]
 
 [[package]]
 name = "abnf-rust"
-version = "2.6.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/4e/a43c3729b8e170cc440d8f22a59c4a8e18d4d0af6cbfc394eb4e04e91bf0/abnf_rust-2.6.0.tar.gz", hash = "sha256:0c83ab787d44a592f59f91ec07d46b7083af2be5ae55c52eef7d1dff7f8f68f0", size = 43729, upload-time = "2026-07-19T15:28:35.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/a9/020e586c238513c60aaa0e85d7b31cc4789cda1ae9f961fe88a495f47426/abnf_rust-2.7.0.tar.gz", hash = "sha256:e9401e1dc817784333fb10f15112bd317e6ee786e7441c8962f4614e2f9e7df7", size = 47973, upload-time = "2026-08-12T22:24:24.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/b9/fa0f931afd886113ed2753f8f5d402be7fa6d3427c34db467e1fd59d2293/abnf_rust-2.6.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:819395580e6e7d815634edf141ea795d92a077c501860de4fcb7f7e4421ab036", size = 435570, upload-time = "2026-07-19T15:28:28.962Z" },
-    { url = "https://files.pythonhosted.org/packages/89/56/81244d55b1e1a2efa906855d4f11ad60fe63c3a738e9257cf327328c7844/abnf_rust-2.6.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b5923ab5f8ae067a07b3a193cbe6240f14a533a49a8400966f77df22ad78ef0a", size = 428603, upload-time = "2026-07-19T15:28:30.323Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/8669c471a165aafea7cf15814a7a699084c8b803742a91637a25ac32f3f3/abnf_rust-2.6.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a8d0fff70212d7bbc21770719262de7aca1d7e311695251a2d519c418b8b0407", size = 471749, upload-time = "2026-07-19T15:28:31.517Z" },
-    { url = "https://files.pythonhosted.org/packages/97/98/20cad97c0c42bd4c2b84c2daa136118307cb4b8af0be7aa2c6adea58e496/abnf_rust-2.6.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4a828156c57763b71d2dafb5dea43d423e8326d28d39bb1f8279e7d74fe20fca", size = 479294, upload-time = "2026-07-19T15:28:32.653Z" },
-    { url = "https://files.pythonhosted.org/packages/21/8b/b7302af80fa38eb6d70501ac367dd1246573c49cb8ea70cff04d16e2066c/abnf_rust-2.6.0-cp310-abi3-win_amd64.whl", hash = "sha256:a9574cc318beac9704c2e0e71b33e05ff36a047012cc94c8fc80238690cf9667", size = 321013, upload-time = "2026-07-19T15:28:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5a/a9a02d4f3c26eb50f38a0d899a363e36f60edbd1f1469d147b28142ee833/abnf_rust-2.7.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:19a11ca5036a9a381c6d0066b65f23f7c1d6a9da9996ef71f20e7be2db133256", size = 439622, upload-time = "2026-08-12T22:24:17.753Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f5/cac3c86b48d87d91bfcd9cd7e56485e6f6b9067dc3a0d57d044b0d9d8fb9/abnf_rust-2.7.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d0e45364408bf034455c40e39f65994765d5e3f4911a51fea2d01d58d8ceaf9c", size = 432997, upload-time = "2026-08-12T22:24:19.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/b687de89a5237baa842cb2fd5c36026101ad4b38b1858fc32db645ae8f57/abnf_rust-2.7.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:88a2b2adf6f8259feb244f983cd26cb2e3b592b7c170eb63f4b8f6f8e14fa4f7", size = 475254, upload-time = "2026-08-12T22:24:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/a5031475170e5b873c2e1e2d243f2c65c1d7919068620b3a7d4a314cb87b/abnf_rust-2.7.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6de525fa8e53060236f6ccc28da5cdcbfead67eae7c293447ac547226337977c", size = 485451, upload-time = "2026-08-12T22:24:21.815Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/2ef2998805c9c57112347021b78e1705474248219d8ba92fcb9c6948b932/abnf_rust-2.7.0-cp310-abi3-win_amd64.whl", hash = "sha256:5b7af1ef0edd01be33831177dad690b547811762ac537eed78a4c400d644d8fb", size = 322986, upload-time = "2026-08-12T22:24:23.114Z" },
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
The v2.8.0 release build failed in **Generate CycloneDX SBOM**:

```
Because only abnf-rust<=2.7.0 is available and abnf[rust] depends on
abnf-rust>=2.8,<3, ... requirements are unsatisfiable.
```

## Cause

The floor raised in #195 named the version being released. The release workflow resolves the runtime dependency closure to build the SBOM, and that happens **before** either package is published — so the bound could never be satisfied at the moment it was checked. The build that would have published `abnf-rust` 2.8.0 was the build that needed it to already exist.

The stale `uv.lock` was a second symptom of the same commit, not a separate cause: regenerating it would not have helped, because the resolution itself is impossible.

## Fix

- Floor is now `>=2.7`, the highest published minor, and the comment states the rule: **raise it in the cycle after the one that introduces the requirement, never in it.**
- `uv.lock` regenerated so it agrees with `pyproject.toml`.
- New `lockfile` CI job runs the release workflow's own `uv export` command on every pull request, plus `uv lock --check`. Nothing outside a tag build exercised that resolution, which is exactly why a fully green PR still broke the release.

Verified locally: the failing command now succeeds and resolves `abnf-rust==2.7.0`.

## Release state

**Nothing was published.** `abnf` never built, so both its publish jobs skipped; the `abnf-rust` PyPI publish was cancelled while it waited on its environment gate. Both projects remain at 2.7.0 on PyPI.

`abnf-rust` 2.8.0 *did* reach TestPyPI. Both publish steps set `skip-existing: true`, so re-running the v2.8.0 tag is idempotent — the version number does not need to be burned.

## Follow-up worth considering

The floor can now only lag the release, so `abnf` 2.8.0 will accept `abnf-rust` 2.7.0 — which after #173 means different surrogate and offset behaviour than the documentation describes. Normal `pip install abnf[rust]` resolves to the newest extension, so exposure is limited to pinned installs, but a runtime version check at backend selection would be a sounder guarantee than a metadata bound. Happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
