### PR TITLE
Release as 2.8.1: v2.8.0 is tagged but unpublishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.8.0
+## 2.8.1
+
+*2.8.0 was tagged but never published: its release build failed before either
+package reached PyPI, and `v*` tags are immutable, so the fix ships under a new
+version.  Nothing was ever available at 2.8.0.*
 
 * **Behaviour change.**  Case-insensitive literal matching now folds case over
   US-ASCII only, per RFC 5234 §2.3, which fixes the character set for literals

--- a/docs/explanation/what-abnf-parses.md
+++ b/docs/explanation/what-abnf-parses.md
@@ -71,7 +71,7 @@ is a property of the decode, not of the parser.
 Both backends handle them, and identically. The Rust engine used to work in
 `char` and `&str` — Unicode *scalar values* and well-formed UTF-8, neither of
 which can hold a surrogate — so a grammar naming one failed to load and input
-containing one failed to cross the FFI. Since 2.8.0 it indexes by code point
+containing one failed to cross the FFI. Since 2.8.1 it indexes by code point
 like the pure-Python backend, and both accept the whole domain
 ([issue #173](https://github.com/declaresub/abnf/issues/173)).
 
@@ -88,7 +88,7 @@ Rule("transfer-coding").parse_all("chun\u212aed")   # KELVIN SIGN: no match
 ```
 
 Full Unicode case folding — Python's `str.casefold()`, which is what `abnf`
-used before 2.8.0 — would match both, because `'\u212a'.casefold() == 'k'`.
+used before 2.8.1 — would match both, because `'\u212a'.casefold() == 'k'`.
 That over-accepts against an ASCII grammar, and it disagrees with peers that
 fold only ASCII, which is where protocol parsers get their differentials.
 

--- a/docs/how-to/use-the-rust-backend.md
+++ b/docs/how-to/use-the-rust-backend.md
@@ -74,7 +74,7 @@ is not reclaimed either, so this is not specific to the Rust backend.
 
 ```{note}
 There is no way to reclaim this memory, and that is deliberate. A private
-`clear_bridge()` used to empty the registry; it was removed in 2.8.0 because it
+`clear_bridge()` used to empty the registry; it was removed in 2.8.1 because it
 could not do the job and broke correctness in the attempt.
 
 Clearing frees very little: a rule's compiled tree embeds the handles of the

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1128,7 +1128,7 @@ def test_h4_parse_error_start_is_codepoint_on_non_ascii():
 # makes literals case-insensitive and fixes their character set as
 # US-ASCII, so case-insensitivity is defined over ASCII and nothing else.
 #
-# Until 2.8.0 both backends used full Unicode folding (Python's
+# Until 2.8.1 both backends used full Unicode folding (Python's
 # `str.casefold()`, the `caseless` crate in Rust), which over-accepted:
 # an ASCII grammar matched '\u017f' (long s) against "s" and '\u212a'
 # (Kelvin sign) against "k", so e.g. RFC 7230 accepted 'compre\u017f\u017f'


### PR DESCRIPTION
Renumbers the pending release to 2.8.1.

## Why

`v2.8.0` is tagged but its build failed before either package reached PyPI, and the repository's tag ruleset (`tag protection (immutable v* tags)`) blocks both `deletion` and `non_fast_forward`. So the tag cannot be moved to the fixed commit.

That rule is worth keeping rather than working around: the tag is what Sigstore signs and what the PEP 740 attestations bind to, so a movable release tag would undermine the provenance chain it exists to protect.

Re-running the existing tag would not help either — the workflow builds from the tag's tree, which still carries the unsatisfiable `abnf-rust>=2.8` floor.

## What changed

- `## 2.8.0` → `## 2.8.1`, with a note recording that 2.8.0 was tagged and never published, so anyone who finds the dangling tag has an explanation.
- The four `2.8.0` references in `docs/` and `tests/` renumbered alongside it — the same set I had to correct once already when 2.7.0 turned out to be taken.

No code changes. 3,910 tests pass on the Rust backend, `uv lock --check` clean.

## After merge

```
git tag -a v2.8.1 -m "abnf 2.8.1"
git push github v2.8.1
```

PyPI has nothing at 2.8.0 or 2.8.1 for either project, so the publish is unobstructed. `abnf-rust` 2.8.0 exists on TestPyPI from the failed run; it is a different version number now, so not even a `skip-existing` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
