### PR TITLE
Fall back instead of crashing when abnf-rust is too old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.8.2
+
+* Fix `import abnf` crashing when `abnf-rust` is older than `abnf`.  The
+  dispatch shim reached for `set_exclude_hook` -- added to the extension in
+  2.8.1 -- outside the `try/except ImportError` that guards backend selection,
+  and `AttributeError` is not an `ImportError`, so the documented fallback to
+  the pure-Python backend never happened.  `abnf` 2.8.1 with `abnf-rust` 2.7.0
+  was a combination the dependency floor allowed, and it died on import.
+
+  `abnf.parser` now checks that the extension provides everything it binds
+  before committing to it, and falls back with a `RuntimeWarning` naming what
+  is missing.  `BACKEND_READY` could not answer this: it is a static flag
+  meaning "this build finished", which an older extension sets too.
+
+  The `[rust]` extra's floor is raised to `abnf-rust>=2.8.1` as well.  The
+  bound is necessary but not sufficient -- it can only name a version already
+  published when the release is built, so it lags by one release, and it is
+  advisory for lockfile installs -- which is why the runtime check carries the
+  guarantee (https://github.com/declaresub/abnf/issues/199).
+
 ## 2.8.1
 
 *2.8.0 was tagged but never published: its release build failed before either

--- a/docs/how-to/use-the-rust-backend.md
+++ b/docs/how-to/use-the-rust-backend.md
@@ -37,6 +37,32 @@ import abnf.parser
 abnf.parser._BACKEND   # 'python' or 'rust'
 ```
 
+## Keep the two packages in step
+
+`abnf` and `abnf-rust` release under one git tag and are meant to be installed
+at the same version. `pip install abnf[rust]` does that for you.
+
+An `abnf-rust` older than the `abnf` importing it is missing whatever the newer
+release added, so `abnf` checks before committing to it. If anything it needs is
+absent, it falls back to the pure-Python backend and warns:
+
+```text
+RuntimeWarning: abnf_rust 2.7.0 is too old for abnf 2.8.2: it does not provide
+set_exclude_hook.  Falling back to the pure-Python backend; upgrade abnf-rust
+to restore it.
+```
+
+Parsing still works — the fallback is a complete implementation — but it is
+slower, so the warning is worth acting on rather than filtering. Upgrading
+`abnf-rust` to match `abnf` restores the Rust backend.
+
+The warning exists because the version bound alone cannot prevent this: the
+floor can only name a version already published when the release is built, so
+it necessarily lags by one release, and it is advisory for anyone installing
+from a lockfile or a private index. Before 2.8.2 a mismatch was not a warning
+but an `AttributeError` from `import abnf`
+([issue #199](https://github.com/declaresub/abnf/issues/199)).
+
 ## When to skip it
 
 The pure-Python implementation is a complete, supported parser and is the right

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,16 @@ rust = [
     # release workflow resolves this dependency (via `uv export`, for
     # the SBOM) *before* publishing, so naming the version being
     # released makes the release unbuildable.  Raise it in the cycle
-    # after the one that introduces the requirement, never in it.
-    'abnf-rust>=2.7,<3',
+    # after the one that introduces the requirement, never in it --
+    # which is what this is: 2.8.1 added `set_exclude_hook` to the
+    # extension, and `abnf` 2.8.1 paired with an older one died on
+    # import (issue #199).
+    #
+    # The bound is necessary but not sufficient: it lags by a release
+    # and is only advisory for lockfile installs, so `abnf.parser`
+    # also checks the backend's capabilities and falls back rather
+    # than crashing.
+    'abnf-rust>=2.8.1,<3',
 ]
 # Documentation toolchain (Sphinx + MyST for Markdown prose + autodoc for the
 # API reference from docstrings).  Kept separate from `dev` so running the test

--- a/src/abnf/parser.py
+++ b/src/abnf/parser.py
@@ -15,8 +15,10 @@ The attribute ``_BACKEND`` on this module is either ``"python"`` or
 
 from __future__ import annotations
 
+import importlib.metadata as _metadata
 import os
 import typing
+import warnings
 
 # The pure-Python implementation is always loaded.  It supplies the
 # canonical Rule / NodeVisitor / exception types (which never have
@@ -43,6 +45,38 @@ from abnf._parser_python import (
 # pyclasses whose Python signatures pyright cannot statically resolve.
 _backend: typing.Any
 
+#: Every name this module binds from the backend.  An extension older
+#: than the `abnf` importing it will be missing whichever were added
+#: since, and reaching for one of those raises `AttributeError` --
+#: which is not an `ImportError`, so the fallback below would not
+#: catch it and `import abnf` would fail outright.  That is issue
+#: #199: `abnf` 2.8.1 with `abnf-rust` 2.7.0, a combination the
+#: dependency floor allowed, died on `set_exclude_hook`.
+#:
+#: `BACKEND_READY` cannot answer this on its own: it is a static flag
+#: meaning "this build finished", and an old extension sets it too.
+_REQUIRED_BACKEND_ATTRS = (
+    "Alternation",
+    "Concatenation",
+    "Repetition",
+    "Option",
+    "Literal",
+    "Prose",
+    "Repeat",
+    "Match",
+    "Node",
+    "LiteralNode",
+    "set_definition_hook",
+    "set_exclude_hook",
+    "bootstrap",
+)
+
+
+def _missing_backend_attrs(module: typing.Any) -> list[str]:
+    """Names this module needs that `module` does not provide."""
+
+    return [name for name in _REQUIRED_BACKEND_ATTRS if not hasattr(module, name)]
+
 if os.environ.get("ABNF_NO_RUST"):
     _backend = _py
     _BACKEND = "python"
@@ -56,6 +90,29 @@ else:
             # (e.g. an in-development build).  Fall back silently.
             msg = "abnf_rust backend not ready"
             raise ImportError(msg)
+
+        _missing = _missing_backend_attrs(_abnf_rust)
+        if _missing:
+            # An `abnf-rust` older than this `abnf`.  Unlike the
+            # in-development case above this is worth saying out loud:
+            # it costs the user the Rust backend, which is a large and
+            # otherwise invisible change in speed, and unlike a
+            # half-built extension it is something they can fix.
+            try:
+                _rust_version = _metadata.version("abnf-rust")
+            except _metadata.PackageNotFoundError:  # pragma: no cover
+                _rust_version = "unknown"
+            warnings.warn(
+                f"abnf_rust {_rust_version} is too old for abnf "
+                f"{_metadata.version('abnf')}: it does not provide "
+                f"{', '.join(_missing)}.  Falling back to the pure-Python "
+                "backend; upgrade abnf-rust to restore it.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            msg = "abnf_rust too old"
+            raise ImportError(msg)
+
         _backend = _abnf_rust
         _BACKEND = "rust"
     except ImportError:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,8 @@
+import json
 import pathlib
+import re
+import subprocess
+import sys
 import textwrap
 import threading
 import warnings
@@ -7,6 +11,7 @@ from typing import cast
 import pytest
 
 from abnf import _parser_python
+from abnf import parser as _parser
 from abnf.parser import (
     ABNFGrammarNodeVisitor,
     ABNFGrammarRule,
@@ -1601,3 +1606,95 @@ def test_53_hand_built_rule_still_honours_a_top_level_alternation():
     rule.first_match_alternation = True
     assert rule.first_match_alternation is True
     assert _HandBuilt("r").parse("ab", 0)[1] == 1
+
+
+# ---------------------------------------------------------------------------
+# Backend capability gate (issue #199).  `abnf` 2.8.1 with `abnf-rust` 2.7.0 --
+# a pairing the dependency floor allowed -- died on `import abnf`, because the
+# dispatch shim reaches for `set_exclude_hook` (added to the extension in that
+# same release) outside the `try/except ImportError` that guards backend
+# selection.  `AttributeError` is not an `ImportError`, so the documented
+# fallback to pure Python never happened.
+#
+# `BACKEND_READY` cannot catch this: it is a static flag meaning "this build
+# finished", and an older extension sets it too.
+# ---------------------------------------------------------------------------
+
+
+def test_199_shim_declares_everything_it_binds():
+    """The required-attribute list must not drift from what the module
+    actually pulls off the backend."""
+    source = pathlib.Path(_parser.__file__).read_text(encoding="utf-8")
+    bound = set(re.findall(r"_backend\.(\w+)", source))
+    declared = set(_parser._REQUIRED_BACKEND_ATTRS)
+    assert bound <= declared, f"bound but not declared: {sorted(bound - declared)}"
+
+
+@pytest.mark.skipif(_parser._BACKEND != "rust", reason="Needs the extension to probe.")
+def test_199_active_backend_satisfies_the_requirements():
+    assert _parser._missing_backend_attrs(_parser._backend) == []
+
+
+def test_199_missing_attribute_is_detected():
+    class _Stub:
+        pass
+
+    stub = _Stub()
+    for name in _parser._REQUIRED_BACKEND_ATTRS:
+        if name != "set_exclude_hook":
+            setattr(stub, name, object())
+    assert _parser._missing_backend_attrs(stub) == ["set_exclude_hook"]
+
+
+@pytest.mark.skipif(
+    _parser._BACKEND != "rust", reason="Needs the extension to build a stub from."
+)
+def test_199_too_old_extension_falls_back_instead_of_crashing():
+    """End to end, in a subprocess: an extension missing a required name
+    must leave `import abnf` working, on the pure-Python backend, with a
+    warning that names what is missing."""
+    program = textwrap.dedent(
+        """
+        import sys, types, warnings, json
+        import abnf_rust as real
+
+        # Stand in for an older build: BACKEND_READY is True, but the
+        # name added in the importing version's release is absent.
+        stub = types.ModuleType("abnf_rust")
+        for name in dir(real):
+            if not name.startswith("_") and name != "set_exclude_hook":
+                setattr(stub, name, getattr(real, name))
+        sys.modules["abnf_rust"] = stub
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import abnf
+            import abnf.parser as parser
+            messages = [str(w.message) for w in caught
+                        if issubclass(w.category, RuntimeWarning)]
+
+        from abnf.parser import Rule
+
+        class G(Rule):
+            pass
+
+        G.create("s = 1*%x61-7A")
+        print(json.dumps({
+            "backend": parser._BACKEND,
+            "messages": messages,
+            "parsed": G("s").parse_all("abc").value,
+        }))
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["backend"] == "python"
+    assert payload["parsed"] == "abc"
+    assert any("set_exclude_hook" in m for m in payload["messages"])
+    assert any("too old" in m for m in payload["messages"])

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ rust = [
 
 [package.metadata]
 requires-dist = [
-    { name = "abnf-rust", marker = "extra == 'rust'", specifier = ">=2.7,<3" },
+    { name = "abnf-rust", marker = "extra == 'rust'", specifier = ">=2.8.1,<3" },
     { name = "check-manifest", marker = "extra == 'dev'", specifier = "==0.51" },
     { name = "furo", marker = "extra == 'docs'", specifier = "==2025.12.19" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.165.2" },
@@ -53,15 +53,15 @@ provides-extras = ["dev", "rust", "docs"]
 
 [[package]]
 name = "abnf-rust"
-version = "2.7.0"
+version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/a9/020e586c238513c60aaa0e85d7b31cc4789cda1ae9f961fe88a495f47426/abnf_rust-2.7.0.tar.gz", hash = "sha256:e9401e1dc817784333fb10f15112bd317e6ee786e7441c8962f4614e2f9e7df7", size = 47973, upload-time = "2026-08-12T22:24:24.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/d1/80e58006d3e47423e919e25019a1ecf37e8ae412eb7cef0278b2d7e225cb/abnf_rust-2.8.1.tar.gz", hash = "sha256:0fe36c1a304b37cce054bc7527d4235d015259787a1d62d0501aa4d378f8ed33", size = 53526, upload-time = "2026-08-14T23:53:25.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/5a/a9a02d4f3c26eb50f38a0d899a363e36f60edbd1f1469d147b28142ee833/abnf_rust-2.7.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:19a11ca5036a9a381c6d0066b65f23f7c1d6a9da9996ef71f20e7be2db133256", size = 439622, upload-time = "2026-08-12T22:24:17.753Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f5/cac3c86b48d87d91bfcd9cd7e56485e6f6b9067dc3a0d57d044b0d9d8fb9/abnf_rust-2.7.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d0e45364408bf034455c40e39f65994765d5e3f4911a51fea2d01d58d8ceaf9c", size = 432997, upload-time = "2026-08-12T22:24:19.163Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/9e/b687de89a5237baa842cb2fd5c36026101ad4b38b1858fc32db645ae8f57/abnf_rust-2.7.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:88a2b2adf6f8259feb244f983cd26cb2e3b592b7c170eb63f4b8f6f8e14fa4f7", size = 475254, upload-time = "2026-08-12T22:24:20.499Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/93/a5031475170e5b873c2e1e2d243f2c65c1d7919068620b3a7d4a314cb87b/abnf_rust-2.7.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6de525fa8e53060236f6ccc28da5cdcbfead67eae7c293447ac547226337977c", size = 485451, upload-time = "2026-08-12T22:24:21.815Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/2ef2998805c9c57112347021b78e1705474248219d8ba92fcb9c6948b932/abnf_rust-2.7.0-cp310-abi3-win_amd64.whl", hash = "sha256:5b7af1ef0edd01be33831177dad690b547811762ac537eed78a4c400d644d8fb", size = 322986, upload-time = "2026-08-12T22:24:23.114Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9f/4cd883d32a485dbc192d86a7fcb37218cb356cc33f2b344ad19253b5eaa9/abnf_rust-2.8.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:44a4e380b1316f43c4be7d99ef824b43db317f11b89443b4f6862114bac1948e", size = 433373, upload-time = "2026-08-14T23:53:17.856Z" },
+    { url = "https://files.pythonhosted.org/packages/83/36/1856eb47319ef39223b5d87b7288212b8ddcefdb261575e1b49f497e1542/abnf_rust-2.8.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ed750bf91ebc185a3a9b8e4415e3ddb2276ffbc51f1e5108916b63bdb9638112", size = 429923, upload-time = "2026-08-14T23:53:19.549Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fb/e6f256bce790eb1644143a36291d666b3e0beb380c60feb829ac1f2c5736/abnf_rust-2.8.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0a06561beb4ad4ac19b661e707e71a5a5b97e7da647488419467f989ab6fbe7a", size = 472754, upload-time = "2026-08-14T23:53:20.96Z" },
+    { url = "https://files.pythonhosted.org/packages/82/52/5a2b7ef6c373f88abfc1ee81e38f8084b699f282cc6eecd119f311ce3dde/abnf_rust-2.8.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:684e0cca4b0769d9f4b23e48c03485d63e4c373d6cdcd3cb7242a4c511bb514a", size = 479244, upload-time = "2026-08-14T23:53:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/b3e6ff4b3c7144ae821d55de2f6f7409403cea8e3b1b5f4448c752e99c4c/abnf_rust-2.8.1-cp310-abi3-win_amd64.whl", hash = "sha256:d17becf65353f68af68a908a97d190009bf73ded068e7e01991d7963ea648b88", size = 318145, upload-time = "2026-08-14T23:53:23.899Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #199.

`abnf` 2.8.1 with `abnf-rust` 2.7.0 — a pairing the dependency floor allowed — failed on `import abnf`:

```
AttributeError: module 'abnf_rust' has no attribute 'set_exclude_hook'
```

`set_exclude_hook` was added to the extension in 2.8.1 for nested exclusions (#179). The dispatch shim reaches for it *outside* the `try/except ImportError` that guards backend selection, and `AttributeError` is not an `ImportError` — so the fallback the module documents never ran.

`BACKEND_READY` could not have caught it. It is a static flag meaning "this build finished", and an older extension sets it too:

```
abnf-rust 2.7.0 BACKEND_READY = True
  set_exclude_hook:    False      <- the newer abnf requires it
  set_definition_hook: True
```

## Fix

`abnf.parser` now checks that the backend provides every name it binds, and treats a missing one as "not usable": fall back to pure Python, and warn.

```
RuntimeWarning: abnf_rust 2.7.0 is too old for abnf 2.8.2: it does not provide
set_exclude_hook.  Falling back to the pure-Python backend; upgrade abnf-rust
to restore it.
```

Warning here, rather than falling back silently as the not-ready case does, because losing the Rust backend is a large and otherwise invisible change in speed — and unlike a half-built extension, this is something the user can fix.

Verified against a stubbed extension: `import abnf` succeeds, `_BACKEND == "python"`, parsing works, and the warning names the missing attribute.

## The floor, too

Raised to `abnf-rust>=2.8.1`, which is only possible now that 2.8.1 is published — the "raise it in the cycle after" rule from #197 working as intended. The bound stays necessary but insufficient: it lags a release by construction, and it is advisory for anyone installing from a lockfile or private index. The runtime check is what actually carries the guarantee.

## Tests

- A test reads the module source for `_backend.<attr>` and asserts the required-name list cannot drift from what is actually bound — the failure mode here was precisely a name being bound that nothing checked for.
- The end-to-end fallback runs in a **subprocess**, since it must reimport `abnf` against a stubbed extension; doing that in-process would leave the rest of the suite on the wrong backend.
- Plus a unit test of the predicate and, on the Rust backend, an assertion that the real extension satisfies the list.

3,914 tests pass on the Rust backend, 1,444 on pure Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
