### PR TITLE
Raise GrammarError for an undefined rule reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+* A reference to a rule that was never defined now raises `GrammarError` on the
+  Rust backend, as it already did on the pure-Python one.  It was an ordinary
+  `ParseError`, which is indistinguishable from "this alternative did not
+  match", so an enclosing `Alternation` or `Repetition` swallowed it as
+  backtracking: given `a = b / "x"` with `b` undefined, the Rust engine matched
+  `"x"` and silently dropped the `b` branch, while pure Python raised.  A typo'd
+  rule name quietly narrowed the grammar rather than reporting a problem.
+
+  The identical defect was fixed for exclusions in 2.8.1; the plain definition
+  lookup one screen below it in `rule.rs` was missed
+  (https://github.com/declaresub/abnf/issues/201).
+
 ## 2.8.2
 
 * Fix `import abnf` crashing when `abnf-rust` is older than `abnf`.  The

--- a/packages/abnf-rust/rust/core/src/rule.rs
+++ b/packages/abnf-rust/rust/core/src/rule.rs
@@ -268,7 +268,17 @@ impl NamedRule {
                 self.name
             ),
         });
-        let def = self.definition().ok_or_else(|| self.parse_error(start))?;
+        // A rule that was never defined is a broken grammar, not input
+        // that failed to match.  Returning a `ParseError` here would be
+        // indistinguishable from "this alternative did not match", so
+        // an enclosing `Alternation` or `Repetition` would swallow it
+        // as backtracking and a typo'd rule name would silently delete
+        // that branch of the grammar.  The pure-Python backend raises
+        // `GrammarError`; panic with the phrase the PyO3 layer maps to
+        // it, the same route `is_excluded` and the recursion guard use.
+        let Some(def) = self.definition() else {
+            panic!("Undefined rule \"{}\"", self.name);
+        };
         let inner = def.lparse(source, start)?;
 
         let excluded = self.exclude();

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1698,3 +1698,66 @@ def test_199_too_old_extension_falls_back_instead_of_crashing():
     assert payload["parsed"] == "abc"
     assert any("set_exclude_hook" in m for m in payload["messages"])
     assert any("too old" in m for m in payload["messages"])
+
+
+# ---------------------------------------------------------------------------
+# Undefined rule references (issue #201).  A rule that was never defined is a
+# broken grammar, not input that failed to match.  The Rust engine returned an
+# ordinary ParseError, which is indistinguishable from "this alternative did
+# not match" -- so an enclosing Alternation or Repetition swallowed it as
+# backtracking and a typo'd rule name silently deleted that branch.
+#
+# The same defect was fixed for exclusions in 2.8.1; the plain definition
+# lookup one screen below it in rule.rs was missed.
+# ---------------------------------------------------------------------------
+
+
+def test_201_undefined_rule_in_an_alternation_raises():
+    """The reported case: the branch must not be silently dropped."""
+
+    class UndefinedInAlternation(Rule):
+        pass
+
+    UndefinedInAlternation.create('a = b / "x"')  # `b` is never defined
+
+    # Input that the *other* alternative matches must still raise: the
+    # grammar is broken regardless of which branch would have won.
+    with pytest.raises(GrammarError, match="Undefined rule"):
+        UndefinedInAlternation("a").parse_all("x")
+
+    with pytest.raises(GrammarError, match="Undefined rule"):
+        UndefinedInAlternation("a").parse_all("zz")
+
+
+def test_201_undefined_rule_in_a_repetition_raises():
+    class UndefinedInRepetition(Rule):
+        pass
+
+    UndefinedInRepetition.create("a = *b")
+
+    with pytest.raises(GrammarError, match="Undefined rule"):
+        UndefinedInRepetition("a").parse_all("")
+
+
+def test_201_undefined_rule_referenced_directly_raises():
+    class UndefinedDirect(Rule):
+        pass
+
+    UndefinedDirect.create("a = b")
+
+    with pytest.raises(GrammarError, match="Undefined rule"):
+        UndefinedDirect("a").parse_all("x")
+
+
+def test_201_forward_reference_still_works_once_defined():
+    """The check must fire on a missing definition, not on definition
+    order: a rule may be referenced before it is defined."""
+
+    class ForwardReference(Rule):
+        pass
+
+    ForwardReference.create('a = b / "x"')
+    ForwardReference.create('b = "y"')
+
+    assert ForwardReference("a").parse_all("y").value == "y"
+    assert ForwardReference("a").parse_all("x").value == "x"


### PR DESCRIPTION
Closes #201.

A rule that was never defined is a broken grammar, not input that failed to match. The Rust engine returned an ordinary `ParseError` — indistinguishable from "this alternative did not match" — so `Alternation` and `Repetition` swallowed it as backtracking:

```python
G.create('a = b / "x"')     # b is never defined
G("a").parse_all("x")       # before: matched (b branch silently dropped)
                            # after:  GrammarError: Undefined rule "b"
```

A typo'd rule name quietly narrowed the grammar, and a test suite asserting only on valid input would never notice.

## Fix

`rule.rs:271` now panics with the phrase the PyO3 layer maps to `GrammarError` — the same route `is_excluded` uses four lines up, and the recursion guard before it.

This is a gap rather than a design choice: the identical defect was fixed for exclusions in 2.8.1, with the reasoning recorded in the changelog ("the Rust engine treated the missing definition as an ordinary parse failure… the grammar silently accepted what it was written to reject"). The plain definition lookup one screen below never got the same treatment.

## Sweep

I checked the engine's other definition lookups for the same shape:

- `visitor.rs:60` — `.expect("=/ used on undefined rule")` is unreachable from the Python API: `a =/ "x"` on an undefined rule raises `AttributeError` on the Python side first, **identically on both backends**.
- `bootstrap.rs:47` — skips undefined rules deliberately.

No sibling instances.

## Tests

Both swallow paths (alternation, repetition), a direct reference, and a forward reference that is defined later — so the check fires on a *missing definition*, not on definition order.

3,918 tests on the Rust backend, 1,448 on pure Python, and the 43-case differential suite still shows zero divergence.

## Note for #203

With this fix, the duck-typed-parser case in #203 now surfaces as `GrammarError` rather than a silent `ParseError` — loud instead of silent, but still divergent from pure Python, which matches. #203 stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
