### PR TITLE
Give a re-entrant parse on a different source its own epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+* A custom parser that re-enters the engine on a *different* source no longer
+  corrupts the enclosing parse.  Memoisation is scoped by epoch and keyed by
+  position alone, so an epoch may only ever see one source; nested entries
+  shared the enclosing parse's epoch, on the reasoning that a callback
+  re-entering the engine is part of the same parse.  The `Parser` protocol is
+  public, though, and a parser you write may parse anything while it runs --
+  after which entries made against the inner source answered lookups against
+  the outer one, and the outer parse returned a wrong result.  The pure-Python
+  backend was never affected: its memo carries the source and checks identity
+  before use.
+
+  The FFI boundary now compares the `str` object's identity, as the
+  pure-Python memo does, and gives a genuinely different source its own epoch.
+  Same-source re-entry keeps sharing, which matters because an epoch change
+  resets the caches it touches -- claiming one unconditionally would wipe the
+  enclosing parse's memo on every callback
+  (https://github.com/declaresub/abnf/issues/202).
+
 * A reference to a rule that was never defined now raises `GrammarError` on the
   Rust backend, as it already did on the pure-Python one.  It was an ordinary
   `ParseError`, which is indistinguishable from "this alternative did not

--- a/packages/abnf-rust/rust/pyo3/src/parsers.rs
+++ b/packages/abnf-rust/rust/pyo3/src/parsers.rs
@@ -97,7 +97,9 @@ impl PyAlternation {
         start: usize,
     ) -> PyResult<Py<LparseIter>> {
         let cps = CodePoints::new(source)?;
-        let result = crate::recursion::call_lparse(|| self.inner.lparse(cps.as_slice(), start))?;
+        let result = crate::recursion::call_lparse(source.as_ptr() as usize, || {
+            self.inner.lparse(cps.as_slice(), start)
+        })?;
         lparse_iter(py, result, source)
     }
 
@@ -150,7 +152,9 @@ impl PyConcatenation {
         start: usize,
     ) -> PyResult<Py<LparseIter>> {
         let cps = CodePoints::new(source)?;
-        let result = crate::recursion::call_lparse(|| self.inner.lparse(cps.as_slice(), start))?;
+        let result = crate::recursion::call_lparse(source.as_ptr() as usize, || {
+            self.inner.lparse(cps.as_slice(), start)
+        })?;
         lparse_iter(py, result, source)
     }
 
@@ -186,7 +190,9 @@ impl PyRepetition {
         start: usize,
     ) -> PyResult<Py<LparseIter>> {
         let cps = CodePoints::new(source)?;
-        let result = crate::recursion::call_lparse(|| self.inner.lparse(cps.as_slice(), start))?;
+        let result = crate::recursion::call_lparse(source.as_ptr() as usize, || {
+            self.inner.lparse(cps.as_slice(), start)
+        })?;
         lparse_iter(py, result, source)
     }
 
@@ -222,7 +228,9 @@ impl PyOption {
         start: usize,
     ) -> PyResult<Py<LparseIter>> {
         let cps = CodePoints::new(source)?;
-        let result = crate::recursion::call_lparse(|| self.inner.lparse(cps.as_slice(), start))?;
+        let result = crate::recursion::call_lparse(source.as_ptr() as usize, || {
+            self.inner.lparse(cps.as_slice(), start)
+        })?;
         lparse_iter(py, result, source)
     }
 
@@ -285,7 +293,9 @@ impl PyLiteral {
         start: usize,
     ) -> PyResult<Py<LparseIter>> {
         let cps = CodePoints::new(source)?;
-        let result = crate::recursion::call_lparse(|| self.inner.lparse(cps.as_slice(), start))?;
+        let result = crate::recursion::call_lparse(source.as_ptr() as usize, || {
+            self.inner.lparse(cps.as_slice(), start)
+        })?;
         lparse_iter(py, result, source)
     }
 
@@ -347,7 +357,9 @@ impl PyProse {
         start: usize,
     ) -> PyResult<Py<LparseIter>> {
         let cps = CodePoints::new(source)?;
-        match crate::recursion::call_lparse(|| self.inner.lparse(cps.as_slice(), start))? {
+        match crate::recursion::call_lparse(source.as_ptr() as usize, || {
+            self.inner.lparse(cps.as_slice(), start)
+        })? {
             Ok(_) => lparse_iter(py, Ok(smallvec::SmallVec::new()), source),
             Err(err) => Err(parse_error_to_pyerr(py, err)),
         }

--- a/packages/abnf-rust/rust/pyo3/src/recursion.rs
+++ b/packages/abnf-rust/rust/pyo3/src/recursion.rs
@@ -24,7 +24,7 @@
 //! tags into the right Python exception.  Other panics resume so
 //! they keep surfacing as `PanicException` via PyO3's defaults.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::Once;
 
@@ -48,6 +48,17 @@ const PYERR_PANIC_TAG: &str = "pycallback-python-error";
 const UNDEFINED_RULE_TAG: &str = "Undefined rule";
 
 thread_local! {
+    /// Identity of the source the innermost active parse is running
+    /// over: the address of the Python `str` object, which is what
+    /// the pure-Python backend compares (`ctx[0] is source`) before
+    /// trusting a memo entry.  Zero when no parse is active.
+    ///
+    /// Not the code-point buffer's address: a nested call widens the
+    /// same `str` into a different pooled buffer, so that would report
+    /// "different source" for every re-entrant call and throw away the
+    /// enclosing parse's memo each time.
+    static CURRENT_SOURCE_ID: Cell<usize> = const { Cell::new(0) };
+
     /// Holds the most recent `PyErr` raised by a `PyCallbackParser`
     /// callback that should propagate (i.e. not a `ParseError`).
     /// Taken by `call_lparse` when it recognises the
@@ -56,6 +67,16 @@ thread_local! {
 }
 
 static HOOK_INSTALLED: Once = Once::new();
+
+/// Restores the enclosing parse's source identity on the way out, so
+/// a nested call cannot leave the wrong one behind.
+struct RestoreSourceId(usize);
+
+impl Drop for RestoreSourceId {
+    fn drop(&mut self) {
+        CURRENT_SOURCE_ID.with(|id| id.set(self.0));
+    }
+}
 
 /// Install the panic hook exactly once per process.
 pub fn install_panic_hook() {
@@ -99,7 +120,7 @@ pub fn propagate_pyerr(err: PyErr) -> ! {
 /// PyCallbackParser-stash panic to the saved `PyErr`.  Any other
 /// panic is re-raised so it surfaces normally via PyO3's
 /// `PanicException`.
-pub fn call_lparse<F>(f: F) -> PyResult<abnf_core::ParseResult>
+pub fn call_lparse<F>(source_id: usize, f: F) -> PyResult<abnf_core::ParseResult>
 where
     F: FnOnce() -> abnf_core::ParseResult,
 {
@@ -112,6 +133,24 @@ where
     // identity.  Nested entries -- a `PyCallbackParser` calling back
     // in -- share the epoch, so intra-parse reuse is preserved.
     let _scope = abnf_core::ParseScope::enter();
+
+    // ...but only while they are parsing the same text.  A custom
+    // parser may call back in on any source it likes, and cache
+    // entries are keyed by position alone, so sharing an epoch across
+    // two sources let the inner parse answer the outer one's lookups
+    // and the outer parse returned a wrong result (issue #202).
+    //
+    // Compare the `str` object's identity, exactly as the pure-Python
+    // memo does, and give a genuinely different source its own epoch.
+    // Same-source re-entry -- the common case -- keeps sharing, which
+    // matters because an epoch change resets the caches it touches:
+    // claiming one unconditionally would wipe the enclosing parse's
+    // memo on every callback.
+    let previous_source = CURRENT_SOURCE_ID.with(Cell::get);
+    let _source_scope = (previous_source != source_id)
+        .then(abnf_core::SourceScope::enter);
+    CURRENT_SOURCE_ID.with(|id| id.set(source_id));
+    let _restore = RestoreSourceId(previous_source);
     match panic::catch_unwind(AssertUnwindSafe(f)) {
         Ok(result) => Ok(result),
         Err(payload) => {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1761,3 +1761,76 @@ def test_201_forward_reference_still_works_once_defined():
 
     assert ForwardReference("a").parse_all("y").value == "y"
     assert ForwardReference("a").parse_all("x").value == "x"
+
+
+# ---------------------------------------------------------------------------
+# Re-entrant parses over a different source (issue #202).  Memoisation is
+# scoped by epoch, and cache entries are keyed by position alone, so an epoch
+# may only ever see one source.  Nested FFI entries shared the enclosing
+# parse's epoch on the reasoning that a callback re-entering the engine is
+# part of the same parse -- but the `Parser` protocol is public, and a custom
+# parser may parse anything it likes while it runs.  Entries made against the
+# inner source then answered lookups against the outer one.
+#
+# The pure-Python backend was never affected: its memo carries the source and
+# checks identity (`ctx[0] is source`) before use.
+# ---------------------------------------------------------------------------
+
+
+def test_202_re_entrant_parse_on_a_different_source():
+    """The reported case: parsing other text mid-parse must not change
+    what the enclosing parse matches."""
+    inner = Repetition(Repeat(0, None), Literal("a"))
+
+    class ReEnter:
+        def lparse(self, source, start):
+            list(inner.lparse("bbbb", 0))  # a different source, mid-parse
+            yield Match([], start)  # then match zero width
+
+    outer = Concatenation(cast(Parser, ReEnter()), inner)
+    assert max(m.start for m in outer.lparse("aaa", 0)) == 3
+
+
+def test_202_re_entrant_parse_on_the_same_source_is_unaffected():
+    """Same-source re-entry keeps sharing the epoch -- an epoch change
+    resets the caches it touches, so claiming one unconditionally would
+    wipe the enclosing parse's memo on every callback."""
+
+    class Ambiguous(Rule):
+        pass
+
+    Ambiguous.create('amb = 1*("a" / "aa")')
+    inner = Ambiguous("amb")
+
+    class SameSource:
+        def lparse(self, source, start):
+            inner.parse(source, 0)  # the same source object
+            yield Match([], start)
+
+    class Outer(Rule):
+        pass
+
+    Outer(
+        "loop",
+        Repetition(
+            Repeat(1, None),
+            Concatenation(cast(Parser, SameSource()), Ambiguous("amb")),
+        ),
+    )
+    source = "a" * 12
+    assert Outer("loop").parse(source, 0)[1] == len(source)
+
+
+def test_202_nested_different_sources_restore_the_outer_scope():
+    """Two levels of re-entry, each on its own text: unwinding must put
+    the enclosing parse back on its own entries."""
+    inner = Repetition(Repeat(0, None), Literal("a"))
+
+    class Deep:
+        def lparse(self, source, start):
+            list(inner.lparse("bb", 0))
+            list(inner.lparse("cccc", 0))
+            yield Match([], start)
+
+    outer = Concatenation(cast(Parser, Deep()), inner)
+    assert max(m.start for m in outer.lparse("aaaa", 0)) == 4


### PR DESCRIPTION
Closes #202.

A custom parser that parses other text mid-parse corrupted the parse that called it:

```python
rep = Repetition(Repeat(0, None), Literal("a"))
# a duck parser whose lparse does: list(rep.lparse("bbbb", 0))
Concatenation(duck, rep).lparse("aaa", 0)
# longest end: 0 under Rust, 3 under pure Python
```

Memoisation is scoped by epoch and keyed by position alone, so an epoch may only ever see one source. Nested FFI entries shared the enclosing parse's epoch, on the reasoning that a `PyCallbackParser` re-entering the engine is part of the same parse. But the `Parser` protocol is public — the docs invite you to write one — and nothing constrains what such a parser parses while it runs.

## Fix

The FFI boundary compares the identity of the Python `str` object — the same test the pure-Python memo makes (`ctx[0] is source`) — and enters a `SourceScope` for a genuinely different source. `is_excluded` already did exactly this for its slice sub-parse; this applies the same rule at the other place a new source can enter the engine.

## Two things it deliberately does not do

I tried both of the fix directions from the issue and rejected them for concrete reasons:

**A fresh epoch for every nested entry.** `ParseCache::bind` resets a *whole cache* when the epoch changes — it is not per-entry tagging. So this wipes the enclosing parse's memo on every callback, turning memoised work back into repeated work in exactly the grammars that need it (ambiguous ones with a callback inside a repetition). I implemented it, watched a test assert the outer parse had lost its own entries, and backed it out.

**Comparing the code-point buffer's address.** A nested call widens the same `str` into a *different* pooled buffer, so this reports "different source" for every re-entrant call and has the same effect as the above.

## Verification

- The reported case now returns 3 on both backends.
- Same-source re-entry through an ambiguous grammar stays fast: 0.4 ms, against 2.8 ms for pure Python on the same shape — no memo thrash.
- Parse benchmarks unchanged; the added work is one thread-local compare per FFI entry.
- 3,921 tests on Rust, 1,451 on pure Python, 55 Rust crate tests, 43-case differential suite at zero divergence, plus the existing re-entrancy/exclusion/threads harness.

Three new tests: the reported case, same-source re-entry, and two levels of nesting each on their own text (unwinding must restore the enclosing scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
