### PR TITLE
Identify rules by type, not by attribute shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+* A duck-typed parser that happens to have a `name` attribute is no longer
+  mistaken for a `Rule` by the Rust backend.  Parsers were identified by
+  attribute shape -- anything with `name` and `lparse` -- so such an object
+  became a definition-less `NamedRule` and its own `lparse` was never called:
+  `Concatenation(Literal("x"), MyParser())` matched `"xz"` on the pure-Python
+  backend and failed on the Rust one, controlled by an attribute that looks
+  incidental.
+
+  It also entered the bridge, a registry keyed by the Python object's
+  *address*.  That is sound for rules, which `Rule._obj_map` keeps alive
+  forever, but not for an arbitrary user object: a freed one's address could
+  be handed to a new `Rule`, which then inherited its stale handle.
+  Reproduced -- defining such a rule wrote into a parser tree built from an
+  unrelated object, and the tree matched input the original parser always
+  rejected.
+
+  Rules are now identified by type.  Everything else with `lparse` takes the
+  callback path, which holds a reference to the object, so it cannot dangle
+  (https://github.com/declaresub/abnf/issues/203).
+
 * A custom parser that re-enters the engine on a *different* source no longer
   corrupts the enclosing parse.  Memoisation is scoped by epoch and keyed by
   position alone, so an epoch may only ever see one source; nested entries

--- a/packages/abnf-rust/rust/pyo3/src/parsers.rs
+++ b/packages/abnf-rust/rust/pyo3/src/parsers.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyString, PyTuple};
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{PyString, PyTuple, PyType};
 
 use abnf_core::{
     arc, Alternation, ArcParser, Concatenation, Literal, LiteralKind, OptionParser, Parser, Prose,
@@ -398,19 +399,31 @@ pub fn extract_parser(obj: &Bound<'_, PyAny>) -> PyResult<ArcParser> {
     if let Ok(p) = obj.cast::<PyProse>() {
         return Ok(p.borrow().inner.clone());
     }
-    // If the value is a Python Rule (or anything else carrying a
-    // `name`+`lparse` shape that fits the parser-by-name contract),
-    // look up — or lazily create — its shadow Rust `NamedRule` in
-    // the bridge registry.  This is the fast path that keeps rule
-    // references purely in Rust at parse time, instead of dispatching
-    // every reference through Python.
-    if obj.hasattr("name")? && obj.hasattr("lparse")? {
+    // If the value is a Python `Rule`, look up — or lazily create —
+    // its shadow Rust `NamedRule` in the bridge registry.  This is the
+    // fast path that keeps rule references purely in Rust at parse
+    // time, instead of dispatching every reference through Python.
+    //
+    // The test is `isinstance`, not the presence of `name` + `lparse`.
+    // Attribute shape caught anything with a `name`, which was wrong
+    // twice over (issue #203): such an object became a
+    // definition-less `NamedRule` whose own `lparse` was then never
+    // called, and it was entered into a registry keyed by the object's
+    // *address* — sound only because `Rule._obj_map` makes rules
+    // immortal, which is not true of an arbitrary user object.  A
+    // freed one's address could be handed to a new `Rule`, which then
+    // inherited its stale handle; defining that rule wrote into a
+    // parser tree built from an unrelated object.
+    static RULE_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    let rule_type = RULE_TYPE.import(obj.py(), "abnf._parser_python", "Rule")?;
+    if obj.is_instance(rule_type)? {
         let handle = crate::bridge::get_or_create(obj)?;
         return Ok(arc(handle));
     }
-    // Last-resort fallback: any other object with an `lparse` method
-    // is wrapped as a `PyCallbackParser`.  Reserved for callers that
-    // pass duck-typed parsers without a `name` attribute.
+    // Any other object with an `lparse` method is wrapped as a
+    // `PyCallbackParser`, which holds a reference to it -- so unlike a
+    // bridge entry, it cannot outlive the object it refers to.  This
+    // is where every duck-typed parser goes, with or without a `name`.
     if obj.hasattr("lparse")? {
         let callback = PyCallbackParser::new(obj.clone().unbind(), "PyCallback");
         let parser: Parser = Parser::External(Arc::new(callback));

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import pathlib
 import re
@@ -6,6 +7,7 @@ import sys
 import textwrap
 import threading
 import warnings
+import weakref
 from typing import cast
 
 import pytest
@@ -1834,3 +1836,76 @@ def test_202_nested_different_sources_restore_the_outer_scope():
 
     outer = Concatenation(cast(Parser, Deep()), inner)
     assert max(m.start for m in outer.lparse("aaaa", 0)) == 4
+
+
+# ---------------------------------------------------------------------------
+# Parser identification (issue #203).  The Rust layer decided that anything
+# with `name` and `lparse` was a Rule, and registered it in the bridge -- a
+# registry keyed by the Python object's *address*.  Two defects followed:
+# such an object became a definition-less `NamedRule` whose own `lparse` was
+# never called, and the registry's soundness argument (rules are immortal,
+# via `Rule._obj_map`) does not hold for an arbitrary user object, so a freed
+# one's address could be handed to a new `Rule` that inherited its handle.
+#
+# Rules are now identified by type.  Everything else with `lparse` goes to the
+# callback path, which holds a reference to the object -- so it cannot dangle.
+# ---------------------------------------------------------------------------
+
+
+def test_203_duck_typed_parser_with_a_name_attribute_is_called():
+    """`name` is an ordinary attribute; it must not change dispatch."""
+
+    class NamedDuck:
+        name = "descriptive"
+
+        def lparse(self, source, start):
+            if start < len(source):
+                yield Match(
+                    [cast(Node, LiteralNode(source[start], start, 1))], start + 1
+                )
+            else:
+                raise ParseError(self, start)
+
+    parser = Concatenation(Literal("x"), cast(Parser, NamedDuck()))
+    match = next(iter(parser.lparse("xz", 0)))
+    assert match.nodes[-1].value == "z"
+
+
+def test_203_a_parser_tree_keeps_its_python_parsers_alive():
+    """The property that makes the address-reuse hazard impossible: an
+    embedded parser is owned by the tree, so its address cannot be
+    recycled while the tree still refers to it."""
+
+    class Duck:
+        name = "duck"
+
+        def lparse(self, source, start):
+            yield Match([cast(Node, LiteralNode(source[start], start, 1))], start + 1)
+
+    duck = Duck()
+    ref = weakref.ref(duck)
+    tree = Concatenation(Literal("x"), cast(Parser, duck))
+    del duck
+    gc.collect()
+    assert ref() is not None, "the tree does not own the parser it was built from"
+
+    del tree
+    gc.collect()
+    assert ref() is None, "the parser outlived every tree referring to it"
+
+
+@pytest.mark.skipif(
+    _parser._BACKEND != "rust", reason="The bridge only exists under Rust."
+)
+def test_203_real_rules_still_take_the_bridge_fast_path():
+    """Identifying rules by type must not cost the optimisation the
+    attribute check existed for."""
+    from abnf_rust._ext import bridge_size  # type: ignore[import-not-found]
+
+    class BridgeFastPath(Rule):
+        pass
+
+    BridgeFastPath.create('inner = "a"')
+    before = bridge_size()
+    BridgeFastPath("outer", Concatenation(Literal("x"), BridgeFastPath("inner")))
+    assert bridge_size() > before


### PR DESCRIPTION
Closes #203.

`extract_parser` treated anything with `name` and `lparse` as a `Rule`. Two defects followed, and I confirmed both.

## Part A — the parser never ran

```python
Concatenation(Literal("x"), MyParser()).lparse("xz", 0)
# pure Python: matches "z".   Rust (before): fails.
```

A duck-typed parser with a descriptive `name` became a definition-less `NamedRule`, so its own `lparse` was never called. Dispatch turned on an attribute that looks incidental — deleting `name` made the same object work.

## Part B — confirmed, and it is cross-object corruption

I filed this as the reviewer's unverified claim; it reproduces. `bridge.rs` states the invariant that makes its pointer keying sound — `Rule._obj_map` keeps every rule alive, so addresses are never recycled — and an arbitrary user object does not satisfy it.

After 2,000 duck parsers were registered and freed, a new `Rule` landed on one's address:

```
Rule s17 reused freed duck's address 0x1059dffd0 (tree #1999)
  ALIASED: the duck-built tree matched 'y' -- the duck always raises ParseError
```

Defining that rule wrote into the `NamedRule` still embedded in a live tree built from the duck. Two unrelated parsers aliasing one engine handle.

This is the hazard I argued was unreachable when closing #187 — that argument assumed only `Rule` objects are registered, which this branch quietly broke.

## Fix

Rules are identified with `isinstance` against `Rule` (cached type lookup). Everything else with `lparse` takes the callback path, which holds a `Py<PyAny>` reference to the object.

That reference is the point: the parser cannot be freed while a tree still refers to it, so the aliasing hazard becomes **structurally impossible** rather than merely unlikely. The new test asserts that with a weakref, rather than hunting for a recycled address:

```
parser still alive while the tree holds it: True
released once the tree is gone: True
```

## Verification

- Part A now matches pure Python on both backends.
- Part B no longer reproduces, and the weakref test explains why.
- Real rules still take the bridge fast path — pinned by a test watching `bridge_size` grow.
- 3,924 tests on Rust, 1,453 on pure Python, 55 Rust crate tests, benchmarks unchanged (the type check runs at grammar-build time, not per parse).

I also swept the layer for other shape-based identification: the only remaining `hasattr` is the intended `lparse` fallback, whose comment I corrected — it no longer describes itself as being for parsers "without a `name` attribute".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
