### PR TITLE
Converge four backend API divergences on the Python reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+* Four small divergences between the backends, each resolved toward the
+  pure-Python implementation (https://github.com/declaresub/abnf/issues/204):
+
+  * A repeat bound too large for a machine word saturates rather than raising
+    `OverflowError`.  Python's ints are unbounded, so `2*99999999999999999999`
+    is odd but valid ABNF the pure-Python backend parses happily -- the bound
+    is never reached -- and `OverflowError` is neither `GrammarError` nor
+    `ParseError`, so it escaped the documented exception contract too.  Such a
+    bound reads back from `Repeat.max` as the machine maximum under the Rust
+    backend; no input can reach either value, so matching is unaffected.
+  * `Literal(('a', 'z')).case_sensitive` reads `False` rather than `True`.  A
+    range compares by code point either way, so this was the attribute alone.
+  * `Node` equality is structural -- name and children, compared recursively
+    -- rather than a comparison of concatenated values, which called two
+    different parse trees equal whenever they spanned the same text.  It
+    silently changed what a user's assertions meant depending on which backend
+    was installed.
+  * `LiteralNode` is unhashable, as it is in pure Python, where defining
+    `__eq__` without `__hash__` makes it so.  `Node` was already unhashable on
+    both, so no parse-tree node is hashable anywhere.
+
 * A duck-typed parser that happens to have a `name` attribute is no longer
   mistaken for a `Rule` by the Rust backend.  Parsers were identified by
   attribute shape -- anything with `name` and `lparse` -- so such an object

--- a/packages/abnf-rust/rust/pyo3/src/nodes.rs
+++ b/packages/abnf-rust/rust/pyo3/src/nodes.rs
@@ -94,13 +94,16 @@ impl PyLiteralNode {
             && self.value.bind(py).as_any().eq(other.value.bind(py).as_any())?)
     }
 
-    fn __hash__(&self, py: Python<'_>) -> PyResult<isize> {
-        // Hash on the same fields `__eq__` compares, and let Python
-        // hash the text so the two agree for every string it can hold.
-        let mut h = self.value.bind(py).as_any().hash()?;
-        h = h.wrapping_mul(1_000_003).wrapping_add(self.offset as isize);
-        h = h.wrapping_mul(1_000_003).wrapping_add(self.length as isize);
-        Ok(h)
+    /// Deliberately absent: defining `__eq__` without `__hash__`
+    /// makes a class unhashable in Python, and the pure-Python
+    /// `LiteralNode` does exactly that.  `Node` is unhashable on both
+    /// backends too, so no parse-tree node is hashable anywhere.
+    /// Adding one here made `set(literal_nodes)` work under the Rust
+    /// backend and raise `TypeError` under the other.
+    #[classattr]
+    #[pyo3(name = "__hash__")]
+    fn __hash__() -> Option<Py<PyAny>> {
+        None
     }
 }
 
@@ -167,8 +170,24 @@ impl PyNode {
     }
 
     fn __richcmp__(&self, py: Python<'_>, other: &Self, op: CompareOp) -> PyResult<bool> {
+        // Structural, as the pure-Python `Node.__eq__` is: name and
+        // children, compared recursively.  Comparing concatenated
+        // values instead called two different parse trees equal
+        // whenever they spanned the same text -- `"xy" / ("x" "y")`
+        // against `("x" "y") / "xy"`, say -- which silently changed
+        // what a user's assertions meant depending on the backend.
         let eq = self.name == other.name
-            && self.value.bind(py).as_any().eq(other.value.bind(py).as_any())?;
+            && self.children.len() == other.children.len()
+            && {
+                let mut equal = true;
+                for (a, b) in self.children.iter().zip(other.children.iter()) {
+                    if !a.bind(py).eq(b.bind(py))? {
+                        equal = false;
+                        break;
+                    }
+                }
+                equal
+            };
         Ok(match op {
             CompareOp::Eq => eq,
             CompareOp::Ne => !eq,

--- a/packages/abnf-rust/rust/pyo3/src/parsers.rs
+++ b/packages/abnf-rust/rust/pyo3/src/parsers.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
-use pyo3::types::{PyString, PyTuple, PyType};
+use pyo3::types::{PyInt, PyString, PyTuple, PyType};
 
 use abnf_core::{
     arc, Alternation, ArcParser, Concatenation, Literal, LiteralKind, OptionParser, Parser, Prose,
@@ -39,7 +39,39 @@ pub struct PyRepeat {
 impl PyRepeat {
     #[new]
     #[pyo3(signature = (min=0, max=None))]
-    fn new(py: Python<'_>, min: usize, max: Option<usize>) -> PyResult<Self> {
+    fn new(py: Python<'_>, min: usize, max: Option<&Bound<'_, PyAny>>) -> PyResult<Self> {
+        // A bound too large for `usize` saturates rather than raising.
+        // Python's ints are unbounded, so `2*99999999999999999999"x"`
+        // is odd but valid ABNF that the pure-Python backend parses
+        // happily -- the bound is simply never reached.  Raising
+        // `OverflowError` here made the two backends disagree, and
+        // `OverflowError` is neither `GrammarError` nor `ParseError`,
+        // so it escaped the documented exception contract as well.
+        // No input can reach `usize::MAX` repetitions, so saturating
+        // is indistinguishable from the unbounded value.
+        let max: Option<usize> = match max {
+            None => None,
+            Some(obj) if obj.is_none() => None,
+            Some(obj) => match obj.extract::<usize>() {
+                Ok(value) => Some(value),
+                // Not an integer at all: report that, not a bound problem.
+                Err(err) if obj.cast::<PyInt>().is_err() => return Err(err),
+                // An integer outside `usize`.  Negative falls through to
+                // the `max < min` check below, exactly as in Python;
+                // anything else is bigger than any input can reach.
+                Err(_) if obj.lt(0i64)? => {
+                    let msg = format!(
+                        "Repeat max ({}) is less than min ({min}); \
+                         a repetition of {min}*{} can never match.",
+                        obj.str()?,
+                        obj.str()?
+                    );
+                    return Err(crate::errors::grammar_error(py, &msg));
+                }
+                Err(_) => Some(usize::MAX),
+            },
+        };
+
         // Mirrors the check in the pure-Python `Repeat.__init__`:
         // `3*2` is an impossible range, and leaving it unvalidated
         // silently behaves as `3*`.  Both backends must reject it
@@ -278,7 +310,11 @@ impl PyLiteral {
                 };
                 return Ok(Self {
                     inner: Literal::range(*lo, *hi).into(),
-                    case_sensitive: true,
+                    // A range compares by code point either way, so
+                    // this attribute is inert -- but the pure-Python
+                    // constructor leaves it at its default, and the
+                    // two backends should read alike.
+                    case_sensitive,
                 });
             }
         }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1909,3 +1909,87 @@ def test_203_real_rules_still_take_the_bridge_fast_path():
     before = bridge_size()
     BridgeFastPath("outer", Concatenation(Literal("x"), BridgeFastPath("inner")))
     assert bridge_size() > before
+
+
+# ---------------------------------------------------------------------------
+# Backend API parity (issue #204).  Four small divergences, grouped because
+# they share a cause: the Rust pyclasses reimplement parts of the Python API
+# surface and drifted from it.  The pure-Python implementation is the
+# reference in each case.
+# ---------------------------------------------------------------------------
+
+
+def test_204_repeat_bound_beyond_usize_is_not_an_error():
+    """Python's ints are unbounded, so this is odd but valid ABNF that
+    the reference backend parses happily -- the bound is never reached.
+    Raising `OverflowError` also escaped the documented exception
+    contract, being neither `GrammarError` nor `ParseError`."""
+
+    class HugeBound(Rule):
+        pass
+
+    HugeBound.create('a = 2*99999999999999999999"x"')
+    assert HugeBound("a").parse_all("xxx").value == "xxx"
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ((3, 2), GrammarError),  # impossible range
+        ((0, -1), GrammarError),  # negative max is < min
+        ((0, "x"), TypeError),  # not a number at all
+    ],
+)
+def test_204_repeat_still_rejects_what_it_should(args, expected):
+    """Saturating a huge bound must not swallow the genuine errors."""
+    with pytest.raises(expected):
+        Repeat(*args)
+
+
+def test_204_range_literal_case_sensitivity_reads_the_same():
+    """A range compares by code point either way, so the attribute is
+    inert -- but it should read alike on both backends."""
+    assert Literal(("a", "z")).case_sensitive is False
+    assert Literal("a").case_sensitive is False
+    assert Literal("a", case_sensitive=True).case_sensitive is True
+
+
+def test_204_node_equality_is_structural():
+    """Comparing concatenated values called two different parse trees
+    equal whenever they spanned the same text."""
+
+    class Flat(Rule):
+        pass
+
+    class Nested(Rule):
+        pass
+
+    Flat.create('a = "xy" / ("x" "y")')
+    Nested.create('a = ("x" "y") / "xy"')
+
+    flat = Flat("a").parse_all("xy")
+    nested = Nested("a").parse_all("xy")
+    assert flat.value == nested.value == "xy"
+    assert len(flat.children) != len(nested.children)
+    assert flat != nested
+
+
+def test_204_node_equality_compares_children_recursively():
+    same = Node("r", cast(Node, Node("c", cast(Node, LiteralNode("a", 0, 1)))))
+    other = Node("r", cast(Node, Node("c", cast(Node, LiteralNode("b", 0, 1)))))
+    assert same == Node("r", cast(Node, Node("c", cast(Node, LiteralNode("a", 0, 1)))))
+    assert same != other
+    # ...and a node is never equal to something that is not one.
+    assert same != LiteralNode("a", 0, 1)
+    assert same != "r"
+
+
+def test_204_parse_tree_nodes_are_unhashable():
+    """`__eq__` without `__hash__` makes a class unhashable in Python,
+    and the reference `LiteralNode` does exactly that.  `Node` is
+    unhashable too, so no parse-tree node is hashable on either
+    backend."""
+    with pytest.raises(TypeError):
+        hash(LiteralNode("a", 0, 1))
+    with pytest.raises(TypeError):
+        hash(Node("x"))


### PR DESCRIPTION
Closes #204. Four small divergences, each resolved toward the pure-Python reference.

| | pure Python | Rust (before) | after |
|---|---|---|---|
| `2*99999999999999999999"x"` | parses | `OverflowError` | parses |
| `Literal(('a','z')).case_sensitive` | `False` | `True` | `False` |
| `Node.__eq__` | structural | value-based | structural |
| `hash(LiteralNode(...))` | `TypeError` | a hash | `TypeError` |

## Repeat bounds

Python's ints are unbounded, so a huge bound is odd but valid ABNF the reference backend parses — it is simply never reached. `OverflowError` is also neither `GrammarError` nor `ParseError`, so it escaped the documented exception contract, the shape of #144 and #170.

Saturating needed care, since three cases had to keep working. Verified on both backends:

| `Repeat(...)` | both backends |
|---|---|
| `(3, 2)` — impossible range | `GrammarError` |
| `(0, -1)` — negative max is `< min` | `GrammarError` |
| `(0, "x")` — not a number | `TypeError` |
| `(2, 10**30)` | accepted, parses |

**One residue, stated plainly:** a bound above `usize::MAX` reads back from `Repeat.max` as `18446744073709551615` under Rust rather than the original integer. No input can reach either value, so matching is unaffected — the tests assert parse parity rather than attribute equality here.

## Node equality

Comparing concatenated values called two *different* parse trees equal whenever they spanned the same text — `"xy" / ("x" "y")` against `("x" "y") / "xy"` — so a user's assertions quietly meant different things on different backends. Now name plus children, compared recursively, as `Node.__eq__` does. Checked against non-`Node` operands and nested trees.

## LiteralNode hashing

Unhashable, per your call on the issue. Defining `__eq__` without `__hash__` makes a class unhashable in Python, which the reference does, and `Node` was already unhashable on both — so no parse-tree node is hashable anywhere now.

## Verification

3,932 tests on Rust, 1,461 on pure Python, 55 Rust crate tests, benchmarks unchanged (none of this is on the parse path). Eight new tests, all passing on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
