### PR TITLE
Pin every action to a release commit, and name the release

### DIFF
--- a/.github/workflows/abnf-tox.yml
+++ b/.github/workflows/abnf-tox.yml
@@ -101,7 +101,7 @@ jobs:
       # — where we deliberately disable build caches to seal source —
       # tests can use a cache: a poisoned cache would surface as a
       # test failure rather than as a tampered release artifact.
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
         workspaces: packages/abnf-rust -> target
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,13 +49,13 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@52485aec7be33610227643b0fe83936b8b5f061a  # v3
+      uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@52485aec7be33610227643b0fe83936b8b5f061a  # v3
+      uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
       with:
         # Category disambiguates the python and rust SARIF uploads in
         # the Code Scanning UI when both finish for the same commit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
         print(f"Set abnf-rust version to {version}")
 
     - name: Build sdist
-      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1
+      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
       with:
         working-directory: packages/abnf-rust
         command: sdist
@@ -204,7 +204,7 @@ jobs:
     - name: Build wheel
       # sccache OFF on release builds: seal source rather than risk
       # a poisoned compilation cache reaching a release wheel.
-      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1
+      uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
       with:
         working-directory: packages/abnf-rust
         target: ${{ matrix.target.maturin-target }}
@@ -291,7 +291,7 @@ jobs:
         path: dist/
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/
         # Make re-runs idempotent.  If a previous attempt for this
@@ -327,7 +327,7 @@ jobs:
         path: dist/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         # Idempotent re-runs.  PyPI rejects duplicate filenames at
         # the project level, so this is purely a "skip what already
@@ -363,7 +363,7 @@ jobs:
         path: dist/
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
@@ -392,7 +392,7 @@ jobs:
         path: dist/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         skip-existing: true
         attestations: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload SARIF to Code Scanning
       if: always()
-      uses: github/codeql-action/upload-sarif@52485aec7be33610227643b0fe83936b8b5f061a  # v3
+      uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
       with:
         sarif_file: zizmor.sarif
         category: zizmor


### PR DESCRIPTION
Supersedes #211.

I audited all nine pinned actions against their upstream tags. Two were not what they looked like.

| action | pinned to | what it actually was |
|---|---|---|
| `Swatinem/rust-cache` | `e18b4977` | **untagged commit**, 45 commits before v2.9.2 |
| `github/codeql-action` | `52485aec` | **an annotated tag object**, not a commit |
| the other seven | — | genuine release commits |

## rust-cache

No tag points at the pinned commit. #211 proposed moving it to `258712b0`, which `compare` reports as **identical to master** — the current tip of the default branch, three commits past the v2.9.2 release. That defeats the point of pinning by SHA: you pin so CI runs a specific reviewed artifact, not whatever has landed since the last release, in an action that runs with access to the CI environment. The `# v2` comment would also have been false, since `v2` points at `6323deb1`.

Now pinned to `6323deb1` (`v2` and `v2.9.2` both point at it), which still picks up the 45 commits of fixes we were behind — including the `credentials.toml` cleanup fix dependabot quoted in #211.

## codeql-action

This one is subtler. `52485aec` is not a commit at all:

```
repos/github/codeql-action/commits/52485aec…  -> 422 No commit found
repos/github/codeql-action/git/tags/52485aec… -> tag "v3" -> commit 7fd177fa…
```

It is the annotated tag object for the **moving** `v3` tag, dereferencing to the v3.35.4 commit. It looks like a SHA pin and satisfies every automated check, but it is only as durable as a git object that no ref points at any more — `v3` has since moved to v3.37.7.

Now pinned to `7fd177fa` directly, with `# v3.35.4`. **CodeQL runs exactly the code it ran before**; only the pin's honesty changes. Upgrading it is a separate decision, and dependabot can now propose it properly.

## Comments

Two pins named a major version or a release branch (`# v1`, `# release/v1`) rather than the release they point at. A comment is what a human reads when auditing a workflow, so it should be checkable — they now name the exact version (`# v1.51.0`, `# v1.14.2`). No SHA changed for those.

## Verification

Every pin re-resolved against upstream tags after the edit: nine of nine are commits that a tag points at, with the comment naming that tag. zizmor reports no findings; all workflow YAML parses.

Please close #211 in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
