### PR TITLE
Update codeql-action to v3.37.7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,13 +49,13 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
+      uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
+      uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
       with:
         # Category disambiguates the python and rust SARIF uploads in
         # the Code Scanning UI when both finish for the same commit.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload SARIF to Code Scanning
       if: always()
-      uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
+      uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
       with:
         sarif_file: zizmor.sarif
         category: zizmor


### PR DESCRIPTION
Follow-up to #213, which repinned `github/codeql-action` to a real commit without changing its version. This moves it two minor versions on, to the commit `v3.37.7` and `v3` both point at.

## Correction to my earlier rationale

I suggested this upgrade on the grounds that it would clear the Node 20 deprecation warning. **It does not.** v3.37.7 declares `using: node20` in `init`, `analyze` and `upload-sarif` — exactly as v3.35.4 does — and the runner force-runs both on Node 24:

```
v3.35.4 (current):   init/analyze/upload-sarif -> using: node20
v3.37.7 (proposed):  init/analyze/upload-sarif -> using: node20
```

That warning stays until upstream moves.

## What it actually buys

Two entries in the range harden precisely the failure that broke CI on #213 today:

- **3.37.5** — a network error while streaming the CodeQL bundle download no longer terminates `init`; it falls back to downloading the bundle before extracting.
- **3.36.2** — exponential backoff when polling SARIF processing status, plus CLI version information cached across steps.

Both bear directly on the 429s and 503s that failed these jobs during the outage. The range also carries CodeQL bundle updates through 2.26.3.

## Risk

The only breaking change in the range is 3.36.0 raising the minimum CodeQL bundle to 2.19.4. We use the default bundle, which is far newer — today's run used 2.26.3 — so it does not affect us.

Verified: the pinned commit is what both `v3.37.7` and `v3` resolve to, the signature is verified, zizmor reports no findings, and all workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
