### PR TITLE
Document what ParseError.parser holds on each backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+* Document that `ParseError.parser` holds the parser object under the
+  pure-Python backend and a description string under the Rust one.  `start`
+  means the same thing either way, and is the attribute to branch on; `parser`
+  is diagnostic output, and reaching into it (`exc.parser.name`) is portable
+  only to pure Python.  The engine builds an error on every failed
+  alternative, so it carries a description prepared once at construction
+  rather than a reference to the parser, which is what keeps backtracking
+  cheap (https://github.com/declaresub/abnf/issues/219).
+
 ## 2.8.3
 
 * A reference to a rule that was never defined now raises `GrammarError` on the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -71,3 +71,17 @@ mind that this checks only for the presence of `lparse`, not its signature.
 
 .. autoexception:: abnf.GrammarWarning
 ```
+
+`ParseError.start` is the code-point offset where the parse failed, and is
+identical on both backends.
+
+`ParseError.parser` describes what failed, but *how* it describes it depends on
+the backend: the pure-Python implementation stores the parser object itself,
+while the Rust backend stores a description string such as `"Concatenation"` or
+`"Literal('a')"`. The engine builds an error on every failed alternative, so it
+carries a description prepared once at construction rather than a reference to
+the parser — which is what keeps backtracking cheap.
+
+Treat `parser` as diagnostic output: `str(exc)` and logging work on both
+backends, and `exc.start` is the attribute to branch on. Code that reaches into
+it, such as `exc.parser.name`, works only under the pure-Python backend.

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -1235,7 +1235,21 @@ class NodeVisitor:
 
 
 class ParseError(Exception):
-    """Raised in response to errors during parsing."""
+    """Raised in response to errors during parsing.
+
+    ``start`` is the code-point offset at which the parse failed, and
+    means the same thing on both backends.
+
+    ``parser`` describes what failed, and is the one attribute whose
+    *type* depends on the backend: here it is the parser object, while
+    the Rust backend supplies a description string (``"Concatenation"``,
+    ``"Literal('a')"``).  An error is constructed on every failed
+    alternative, so that backend carries a description prepared once at
+    construction rather than a reference to the parser -- which is what
+    keeps backtracking cheap.  Treat it as diagnostic output rather than
+    something to reach into; ``str(exc)`` and ``exc.start`` behave
+    identically either way.
+    """
 
     def __init__(self, parser: Parser, start: int, *args: typing.Any):
         # it turns out that calling super().__init__(*args) is quite slow.  Because

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2065,3 +2065,31 @@ def test_218_a_valid_exclusion_still_excludes():
     assert StillExcludes("word").parse_all("go").value == "go"
     with pytest.raises(ParseError):
         StillExcludes("word").parse_all("stop")
+
+
+# ---------------------------------------------------------------------------
+# ParseError attributes (issue #219).  `start` means the same thing on both
+# backends.  `parser` does not: pure Python stores the parser object, the Rust
+# engine a description string prepared once at construction, because an error
+# is built on every failed alternative.  Documented rather than reconciled --
+# carrying the object would put an allocation back on the backtracking path
+# for an attribute only diagnostics read.
+# ---------------------------------------------------------------------------
+
+
+def test_219_parse_error_start_is_the_documented_contract():
+    from abnf.grammars import rfc3986
+
+    with pytest.raises(ParseError) as excinfo:
+        rfc3986.Rule("URI").parse_all("not a uri")
+    assert excinfo.value.start == 0
+    # `str()` works on both backends, whatever `parser` holds.
+    assert str(excinfo.value).endswith(": 0")
+
+
+def test_219_parse_error_parser_is_documented_as_backend_dependent():
+    """Pin the documentation, not the type: the docstring must keep
+    warning that reaching into `parser` is not portable."""
+    doc = ParseError.__doc__ or ""
+    assert "description string" in doc
+    assert "start" in doc


### PR DESCRIPTION
Closes #219.

`ParseError.start` means the same thing on both backends. `ParseError.parser` does not: the pure-Python implementation stores the parser object, the Rust engine a description string.

```python
except ParseError as e:
    e.start     # identical on both backends
    str(e)      # works on both
    e.parser    # Concatenation instance / 'Concatenation'
```

## Why documented rather than reconciled

Carrying the object would mean threading a `Py<PyAny>` through the core for every parser that can fail — and errors are constructed on **every failed alternative**, which is precisely the allocation the pre-formatted description exists to avoid.

For an attribute nothing reads except diagnostics, that is the wrong trade. `e.parser` appears exactly once in this repo, in an identity assertion that holds either way.

So the class docstring and the API reference now say what each backend stores, and give the guidance that follows: branch on `start`, print `str(exc)`, treat `parser` as diagnostic output.

## Tests

One asserts the portable contract (`start`, `str()`), one pins the documentation itself — so the warning cannot quietly disappear while the divergence remains.

3,938 tests on Rust, and the same on pure Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
