### PR TITLE
Preserve values returned by a custom parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+* A value returned by a custom parser is no longer replaced by source text.
+  Since 2.8.1 the engine's terminals are spans of the source and their values
+  are produced by slicing it, which is sound for nodes the engine builds --
+  but a node handed *in* by a parser you write need not correspond to any
+  span.  Returning a normalised or synthesised value is a legitimate thing to
+  do, and the pure-Python backend keeps it; the Rust backend silently
+  substituted whatever text sat at that offset.  Such nodes now carry their
+  own value across the boundary, as code points, so a surrogate survives too
+  (https://github.com/declaresub/abnf/issues/220).
+
+  Parse performance is unaffected: the new node kind is behind an `Arc`, as
+  `Node`'s children already were.  Holding it inline, or behind a `Box`, cost
+  5-9% on the benchmarks -- node lists are cloned on every match extension, so
+  the variant's size and its clone land on every parse whether or not a
+  grammar ever produces one.
+
 * Document that `ParseError.parser` holds the parser object under the
   pure-Python backend and a description string under the Rust one.  `start`
   means the same thing either way, and is the attribute to branch on; `parser`

--- a/packages/abnf-rust/rust/core/src/lib.rs
+++ b/packages/abnf-rust/rust/core/src/lib.rs
@@ -47,7 +47,7 @@ pub use error::ParseError;
 pub use literal::{Literal, LiteralKind};
 pub use matcher::Match;
 pub use meta_grammar::{build_meta_grammar, install_meta_grammar};
-pub use node::{LiteralNode, Node, NodeKind};
+pub use node::{ForeignNode, LiteralNode, Node, NodeKind};
 pub use option::OptionParser;
 pub use parser::{arc, ArcParser, ExternalParser, MatchList, NodeList, ParseResult, Parser, Src};
 pub use prose::Prose;

--- a/packages/abnf-rust/rust/core/src/node.rs
+++ b/packages/abnf-rust/rust/core/src/node.rs
@@ -75,11 +75,45 @@ impl LiteralNode {
     }
 }
 
+/// A terminal node supplied by an embedded Python parser, carrying the
+/// text that parser reported.
+///
+/// Engine-built terminals are spans of the source ([`LiteralNode`]),
+/// which is what lets the PyO3 layer produce their values by slicing.
+/// A node handed *in* by a `PyCallbackParser` need not correspond to
+/// any span: a custom parser may legitimately return a normalised or
+/// synthesised value, and the pure-Python backend keeps it.  Slicing
+/// the source for one of these replaced it with unrelated text
+/// (issue #220), so these carry their own.
+///
+/// Code points rather than a Rust string, for the same reason the
+/// source is: the value may contain a lone surrogate.
+#[derive(Debug, Clone)]
+pub struct ForeignNode {
+    pub value: Box<[u32]>,
+    /// Offset the parser reported.  Not necessarily where `value`
+    /// appears in the source -- it need not appear there at all.
+    pub offset: usize,
+    pub length: usize,
+}
+
+impl ForeignNode {
+    pub fn new(value: Box<[u32]>, offset: usize, length: usize) -> Self {
+        Self { value, offset, length }
+    }
+}
+
 /// Sum type for parse-tree children.
 #[derive(Debug, Clone)]
 pub enum NodeKind {
     Internal(Node),
     Literal(LiteralNode),
+    /// Behind an `Arc`, as `Node`'s children are, and for the same
+    /// reason: node lists are cloned on every match extension, so this
+    /// variant's clone lands on every parse whether or not a grammar
+    /// ever produces one.  Inline it also made `NodeKind` 40 bytes
+    /// rather than 32.
+    Foreign(Arc<ForeignNode>),
 }
 
 impl NodeKind {
@@ -94,6 +128,13 @@ impl NodeKind {
             NodeKind::Literal(l) => {
                 out.extend(
                     l.span(src)
+                        .iter()
+                        .map(|cp| char::from_u32(*cp).unwrap_or(char::REPLACEMENT_CHARACTER)),
+                );
+            }
+            NodeKind::Foreign(f) => {
+                out.extend(
+                    f.value
                         .iter()
                         .map(|cp| char::from_u32(*cp).unwrap_or(char::REPLACEMENT_CHARACTER)),
                 );
@@ -113,6 +154,11 @@ impl NodeKind {
     pub fn span_bounds(&self) -> Option<(usize, usize)> {
         match self {
             NodeKind::Literal(l) => Some((l.offset, l.offset + l.length)),
+            // A foreign node's text is its own, so its span says where
+            // the parser claims it sat, not where its value can be
+            // read from.  Callers computing a value from a span must
+            // check `contains_foreign` first.
+            NodeKind::Foreign(f) => Some((f.offset, f.offset + f.length)),
             NodeKind::Internal(n) => n.children.iter().fold(None, |acc, c| {
                 match (acc, c.span_bounds()) {
                     (None, s) => s,
@@ -123,3 +169,4 @@ impl NodeKind {
         }
     }
 }
+

--- a/packages/abnf-rust/rust/core/src/visitor.rs
+++ b/packages/abnf-rust/rust/core/src/visitor.rs
@@ -153,6 +153,9 @@ fn visit_repeat(node: &Node, src: Src<'_>) -> Repeat {
                     saw_star = true;
                 }
             }
+            // The meta-grammar builds its own trees, so no node here
+            // came from an embedded Python parser.
+            NodeKind::Foreign(_) => {}
         }
     }
     let min = if min_src.is_empty() {

--- a/packages/abnf-rust/rust/pyo3/src/nodes.rs
+++ b/packages/abnf-rust/rust/pyo3/src/nodes.rs
@@ -25,9 +25,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use pyo3::types::PyList;
 
-use abnf_core::{LiteralNode, Match, Node, NodeKind};
+use abnf_core::{ForeignNode, LiteralNode, Match, Node, NodeKind};
 
-use crate::source::substring;
+use crate::source::{from_code_points, substring, CodePoints};
 
 // ----------------------------------------------------------------
 // LiteralNode
@@ -206,18 +206,55 @@ impl PyNode {
     /// rather than a concatenation of the children's values: a node
     /// covers a contiguous run of the source, so the two are the same
     /// text.
-    pub fn from_rust(py: Python<'_>, n: &Node, source: &Bound<'_, PyString>) -> PyResult<Self> {
+    pub fn from_rust(
+        py: Python<'_>,
+        n: &Node,
+        source: &Bound<'_, PyString>,
+    ) -> PyResult<(Self, bool)> {
         let mut children: Vec<Py<PyAny>> = Vec::with_capacity(n.children.len());
+        let mut foreign = false;
         for child in n.children.iter() {
-            children.push(node_kind_to_py(py, child, source)?);
+            let (obj, child_foreign) = node_kind_to_py(py, child, source)?;
+            foreign |= child_foreign;
+            children.push(obj);
         }
-        let value = span_value(py, n.children.iter(), source)?;
-        Ok(Self {
-            name: n.name.as_ref().to_string(),
-            value: value.unbind(),
-            children,
-        })
+        // One slice of the source covers this node -- unless something
+        // below it carries its own text, in which case join the parts,
+        // which the children have already computed (issue #220).
+        let value = if foreign {
+            join_child_values(py, &children)?
+        } else {
+            span_value(py, n.children.iter(), source)?
+        };
+        Ok((
+            Self {
+                name: n.name.as_ref().to_string(),
+                value: value.unbind(),
+                children,
+            },
+            foreign,
+        ))
     }
+}
+
+/// Concatenate the `value` of each already-converted child.  Used only
+/// for a node with a foreign descendant, where slicing the source
+/// would not reproduce the text.
+fn join_child_values<'py>(
+    py: Python<'py>,
+    children: &[Py<PyAny>],
+) -> PyResult<Bound<'py, PyString>> {
+    let mut joined = PyString::new(py, "").unbind();
+    for child in children {
+        let part = child.bind(py).getattr("value")?;
+        joined = joined
+            .bind(py)
+            .as_any()
+            .add(part)?
+            .cast_into::<PyString>()?
+            .unbind();
+    }
+    Ok(joined.into_bound(py))
 }
 
 /// The text spanned by `nodes`: from the first descendant literal to
@@ -244,15 +281,44 @@ where
     }
 }
 
-/// Convert a `NodeKind` to a Python object.
+/// Convert a `NodeKind` to a Python object, reporting whether the
+/// subtree contains a node whose text is not a span of the source.
+///
+/// The flag is accumulated on the way up rather than recomputed by
+/// walking each subtree, which would make building a tree quadratic --
+/// measured at 13-17% on the parse benchmarks when this fix was first
+/// written that way.
 fn node_kind_to_py(
     py: Python<'_>,
     kind: &NodeKind,
     source: &Bound<'_, PyString>,
-) -> PyResult<Py<PyAny>> {
+) -> PyResult<(Py<PyAny>, bool)> {
     Ok(match kind {
-        NodeKind::Internal(n) => Py::new(py, PyNode::from_rust(py, n, source)?)?.into_any(),
-        NodeKind::Literal(l) => Py::new(py, PyLiteralNode::from_rust(l, source)?)?.into_any(),
+        NodeKind::Internal(n) => {
+            let (node, foreign) = PyNode::from_rust(py, n, source)?;
+            (Py::new(py, node)?.into_any(), foreign)
+        }
+        NodeKind::Literal(l) => (
+            Py::new(py, PyLiteralNode::from_rust(l, source)?)?.into_any(),
+            false,
+        ),
+        // Carries its own text, so it is handed back verbatim rather
+        // than re-sliced from the source (issue #220).
+        NodeKind::Foreign(f) => {
+            let value = from_code_points(py, &f.value)?;
+            (
+                Py::new(
+                    py,
+                    PyLiteralNode {
+                        value: value.unbind(),
+                        offset: f.offset,
+                        length: f.length,
+                    },
+                )?
+                .into_any(),
+                true,
+            )
+        }
     })
 }
 
@@ -320,10 +386,17 @@ impl PyMatch {
 impl PyMatch {
     pub fn from_rust(py: Python<'_>, m: &Match, source: &Bound<'_, PyString>) -> PyResult<Self> {
         let mut nodes = Vec::with_capacity(m.nodes.len());
+        let mut foreign = false;
         for nk in &m.nodes {
-            nodes.push(node_kind_to_py(py, nk, source)?);
+            let (obj, node_foreign) = node_kind_to_py(py, nk, source)?;
+            foreign |= node_foreign;
+            nodes.push(obj);
         }
-        let cached_value = span_value(py, m.nodes.iter(), source)?;
+        let cached_value = if foreign {
+            join_child_values(py, &nodes)?
+        } else {
+            span_value(py, m.nodes.iter(), source)?
+        };
         Ok(Self {
             nodes,
             start: m.start,
@@ -358,11 +431,23 @@ fn py_to_node_kind(obj: &Bound<'_, PyAny>) -> PyResult<NodeKind> {
     //
     // A terminal contributes only its span; the text itself is read
     // back out of the source when the tree is rebuilt for Python.
+    // Terminals coming *in* from Python keep their own text.  The
+    // engine's own terminals are spans of the source, which is what
+    // lets their values be produced by slicing -- but a custom parser
+    // may return a normalised or synthesised value, and discarding it
+    // silently replaced it with unrelated source text (issue #220).
     if let Ok(lit) = obj.cast::<PyLiteralNode>() {
         let lit = lit.borrow();
-        return Ok(NodeKind::Literal(LiteralNode::new(lit.offset, lit.length)));
+        let value = CodePoints::new(lit.value.bind(obj.py()))?;
+        return Ok(NodeKind::Foreign(Arc::new(ForeignNode::new(
+            value.as_slice().into(),
+            lit.offset,
+            lit.length,
+        ))));
     }
-    if let (Ok(offset_obj), Ok(length_obj)) = (obj.getattr("offset"), obj.getattr("length")) {
+    if let (Ok(value_obj), Ok(offset_obj), Ok(length_obj)) =
+        (obj.getattr("value"), obj.getattr("offset"), obj.getattr("length"))
+    {
         if let (Ok(offset), Ok(length)) = (
             offset_obj.extract::<usize>(),
             length_obj.extract::<usize>(),
@@ -372,7 +457,13 @@ fn py_to_node_kind(obj: &Bound<'_, PyAny>) -> PyResult<NodeKind> {
                 .and_then(|n| n.extract())
                 .unwrap_or_else(|_| "literal".to_string());
             if name == "literal" {
-                return Ok(NodeKind::Literal(LiteralNode::new(offset, length)));
+                let value_str = value_obj.cast::<PyString>()?;
+                let value = CodePoints::new(value_str)?;
+                return Ok(NodeKind::Foreign(Arc::new(ForeignNode::new(
+                    value.as_slice().into(),
+                    offset,
+                    length,
+                ))));
             }
         }
     }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2093,3 +2093,60 @@ def test_219_parse_error_parser_is_documented_as_backend_dependent():
     doc = ParseError.__doc__ or ""
     assert "description string" in doc
     assert "start" in doc
+
+
+# Values returned by a custom parser (issue #220).  Engine-built terminals are
+# spans of the source, which is what lets their values be produced by slicing
+# it (#173).  A node handed *in* by a custom parser need not correspond to any
+# span: returning a normalised or synthesised value is a legitimate thing to
+# write, and the pure-Python backend keeps it.  Slicing the source for one of
+# those silently replaced it with unrelated text.
+# ---------------------------------------------------------------------------
+
+
+class _Synth:
+    """Returns a value that is not the text it spans."""
+
+    def lparse(self, source, start):
+        yield Match([cast(Node, LiteralNode("SYNTH", 0, 2))], 2)
+
+
+def test_220_a_returned_value_is_preserved():
+    match = next(iter(Concatenation(cast(Parser, _Synth())).lparse("abc", 0)))
+    assert match.nodes[0].value == "SYNTH"
+
+
+def test_220_an_enclosing_node_includes_the_returned_value():
+    """The enclosing value cannot be one slice of the source any more,
+    so it has to be joined from the parts."""
+
+    class Wrapper(Rule):
+        pass
+
+    Wrapper("wrap", Concatenation(cast(Parser, _Synth()), Literal("c")))
+    assert Wrapper("wrap").parse_all("abc").value == "SYNTHc"
+
+
+def test_220_a_returned_value_may_contain_a_surrogate():
+    """The value crosses the boundary as code points, so it is subject
+    to the same domain as the source (#173)."""
+
+    class Surrogate:
+        def lparse(self, source, start):
+            yield Match([cast(Node, LiteralNode("\ud800x", 0, 2))], 2)
+
+    match = next(iter(Concatenation(cast(Parser, Surrogate())).lparse("abc", 0)))
+    assert match.nodes[0].value == "\ud800x"
+
+
+def test_220_engine_built_values_are_unchanged():
+    """The slicing fast path still applies to everything the engine
+    builds itself, which is all of a normal parse."""
+
+    class Ordinary(Rule):
+        pass
+
+    Ordinary.create("s = 1*%x61-7A")
+    node = Ordinary("s").parse_all("abc")
+    assert node.value == "abc"
+    assert [c.value for c in node.children] == ["a", "b", "c"]


### PR DESCRIPTION
Closes #220.

Since 2.8.1 the engine's terminals are spans of the source, and their values are produced by slicing it (#173). That is sound for nodes the engine builds. It is not sound for a node handed **in** by a custom parser, which need not correspond to any span:

```python
class Synth:
    def lparse(self, source, start):
        yield Match([LiteralNode("SYNTH", 0, 2)], 2)

# value was 'ab' -- the source text at that offset -- not 'SYNTH'
```

Returning a normalised or synthesised value is a legitimate thing to write against the documented `Parser` protocol, and the pure-Python backend keeps it. Nothing errored; the value was simply replaced.

## The fix

`NodeKind` gains a `Foreign` variant carrying its own text as code points, so a returned value survives the round trip — including one containing a lone surrogate, for the same reason the source is code points.

A node with such a descendant cannot take the one-slice shortcut for its own value, so it joins its children's instead. The flag saying which applies is accumulated on the way up, during the walk that was already happening.

| | pure Python | Rust before | after |
|---|---|---|---|
| returned value | `SYNTH` | `ab` | `SYNTH` |
| enclosing node's value | `SYNTHc` | `abc` | `SYNTHc` |
| value with a surrogate | preserved | replaced | preserved |
| engine-built values | `abc` | `abc` | `abc` |

## Performance, which took three tries

Benchmarks are back at baseline, but two earlier shapes of this fix were not — and the reasons seem worth recording, since both were invisible until measured:

- **Deciding per node by walking the subtree** (`contains_foreign`) made tree building quadratic: **13–17%**.
- **Holding `ForeignNode` inline** grew `NodeKind` from 32 to 40 bytes; behind a **`Box`**, its clone became a branch with a heap-allocating arm. Either cost **5–9%** — node lists are cloned on every match extension in `Concatenation` and `Repetition`, so a variant no ordinary grammar ever produces was still paying on every parse.

`Arc<ForeignNode>` is what `Node` already does with its children, for exactly this reason: clone is an atomic increment. A controlled A/B — stash, rebuild, measure, restore, rebuild, measure — puts the benchmarks at baseline:

| | baseline | this branch |
|---|---|---|
| rfc3986_uri | 59.13 | 60.00 |
| rfc5322_mailbox | 329.75 | 329.29 |
| rfc7230_request_line | 19.37 | 19.92 |
| rfc9051_astring | 7.33 | 7.33 |

3,936 tests on Rust, 1,465 on pure Python, 55 Rust crate tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
