### PR TITLE
Require a changelog entry for library changes

### DIFF
--- a/.github/workflows/abnf-tox.yml
+++ b/.github/workflows/abnf-tox.yml
@@ -164,3 +164,90 @@ jobs:
       run: |
         uv export --no-dev --extra rust --no-hashes --no-emit-project \
           --format requirements-txt -o "$RUNNER_TEMP/requirements.txt"
+
+  # ----------------------------------------------------------------
+  # Changelog entry
+  # ----------------------------------------------------------------
+  #
+  # A change to the library that ships without a changelog entry is
+  # invisible to users, and the way entries go missing is rarely a
+  # decision: `## Unreleased` exists only *between* releases, so an
+  # edit anchored on that heading silently does nothing in the window
+  # right after one is cut.  Checking here catches the omission
+  # whatever caused it.
+  #
+  # Scoped to the library itself.  CI, docs and tooling changes do not
+  # need an entry, and requiring one for them is how a check like this
+  # becomes noise that people learn to route around.
+
+  changelog:
+    name: Changelog entry
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+        # Needed to diff against the merge base.
+        fetch-depth: 0
+
+    - name: A library change carries a changelog entry
+      env:
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        python3 - <<'PY'
+        import os, pathlib, subprocess, sys
+
+        WATCHED = ("src/", "packages/abnf-rust/rust/")
+        CHANGELOG = "CHANGELOG.md"
+
+        def git(*args):
+            return subprocess.run(
+                ["git", *args], capture_output=True, text=True, check=True
+            ).stdout
+
+        base = f"origin/{os.environ['BASE_REF']}"
+        merge_base = git("merge-base", base, "HEAD").strip()
+        changed = git("diff", "--name-only", merge_base, "HEAD").split()
+
+        code = [p for p in changed if p.startswith(WATCHED)]
+        if not code:
+            print("No library change; a changelog entry is not required.")
+            sys.exit(0)
+
+        # The entry has to land in the Unreleased section, not in an
+        # already-released one.
+        text = pathlib.Path(CHANGELOG).read_text(encoding="utf-8").splitlines()
+        try:
+            start = text.index("## Unreleased")
+        except ValueError:
+            print(
+                f"::error::{len(code)} library file(s) changed, but {CHANGELOG} has "
+                "no '## Unreleased' section.  Add one above the most recent release."
+            )
+            sys.exit(1)
+        end = next(
+            (i for i, l in enumerate(text[start + 1 :], start + 1) if l.startswith("## ")),
+            len(text),
+        )
+        unreleased = set(text[start + 1 : end])
+
+        added = [
+            l[1:]
+            for l in git("diff", "-U0", merge_base, "HEAD", "--", CHANGELOG).splitlines()
+            if l.startswith("+") and not l.startswith("+++")
+        ]
+        if not any(l in unreleased for l in added):
+            print(
+                f"::error::{len(code)} library file(s) changed, but this branch adds "
+                f"nothing to the '## Unreleased' section of {CHANGELOG}.  "
+                "Note that heading only exists between releases -- if a release was "
+                "just cut, add the section back rather than editing a released one."
+            )
+            for p in code[:10]:
+                print(f"  changed: {p}")
+            sys.exit(1)
+
+        print(f"{len(code)} library file(s) changed, and Unreleased gained an entry.")
+        PY


### PR DESCRIPTION
A change to the library that ships without a changelog entry is invisible to users, and entries go missing for a reason that is not a decision:

**`## Unreleased` exists only *between* releases.** An edit anchored on that heading silently does nothing in the window right after one is cut — `str.replace` matches nothing, returns the string unchanged, and reports success. That happened twice in one afternoon on this repo. I caught the second by reading the commit's file list, which is not a control.

## What it does

On pull requests: work out the merge base, and if any file under `src/` or `packages/abnf-rust/rust/` changed, require the branch to have added a line inside the `## Unreleased` section.

An entry added under an already-released heading does not count — that is the same mistake wearing a different hat, and it is what you get if you "fix" the missing-section error by editing the section above it.

Scoped deliberately: CI, docs and tooling changes need no entry. Requiring one for them is how a check like this turns into noise that people learn to route around.

## Verified against real branches

| case | result |
|---|---|
| #229 (library fix, entry present) | PASS |
| the same branch with its entry removed | **FAIL** — names the missing section |
| an entry filed under a released heading | **FAIL** |
| #228 (touches `src/`, entry present) | PASS |
| this branch (CI only) | PASS — exempt |

## One thing to know

This job is **not** among the ruleset's required status checks, so it reports without blocking a merge — the same is true of `Release deps resolve`, which is what caught dependabot's duplicated pins in #210. Both show red and are easy to miss if nobody looks.

If you want either to actually block, they would need adding to the ruleset as required contexts (`Changelog entry`, `Release deps resolve`). I have not touched the ruleset — that is repo governance, and your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
