### PR TITLE
Stop rejecting URIs whose host begins like an IPv4 address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+* `abnf.grammars.rfc3986` and `abnf.grammars.rfc3987` accept URIs and IRIs they
+  used to reject.  `host` set `first_match_alternation`, citing RFC 3986
+  section 3.2.2 -- but that section is about attributing a match of the *whole*
+  host, while first match commits to `IPv4address` on a **prefix**.  Given
+  `http://1.2.3.4.5/`, `IPv4address` matched `1.2.3.4`, `reg-name` was never
+  tried, and the URI was rejected; so was any host of the shape
+  `1.2.3.4.in-addr.arpa`, which is an ordinary reverse-DNS name.  `rfc3987`
+  applied the same setting to every rule in the module, in a loop.
+
+  Nothing is lost by removing it: longest-match alternation already attributes
+  a full IPv4 host to `IPv4address` rather than `reg-name`, because the two tie
+  and the tie is broken by declaration order -- which is exactly what section
+  3.2.2 asks for.  Across a 48-case corpus the only changes are five
+  rejections becoming acceptances; no input that already parsed changes its
+  value or its parse tree (https://github.com/declaresub/abnf/issues/232).
+
 * `Node`, `LiteralNode` and `Match` can be subclassed under the Rust backend,
   as they always could under the pure-Python one.  The pyclasses were final,
   so `class MyNode(Node)` raised `TypeError` -- against a how-to that says

--- a/src/abnf/grammars/rfc3986.py
+++ b/src/abnf/grammars/rfc3986.py
@@ -55,5 +55,14 @@ class Rule(_Rule):
     ]
 
 
-# see https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2 .
-Rule("host").first_match_alternation = True
+# RFC 3986 section 3.2.2 says that a host matching IPv4address "should be
+# considered an IPv4 address literal and not a reg-name".  That is a rule
+# about attributing a match of the whole host, and longest-match alternation
+# already satisfies it: a full IPv4 host ties with reg-name, and the tie is
+# broken by declaration order, which puts IPv4address first.
+#
+# `host` used to set `first_match_alternation`, citing that section.  Under
+# first match the alternation commits to IPv4address on a *prefix*: given
+# `1.2.3.4.5`, IPv4address matched `1.2.3.4`, reg-name was never tried, and
+# the whole URI was rejected -- as was any host of the shape
+# `1.2.3.4.in-addr.arpa`.  See https://github.com/declaresub/abnf/issues/232 .

--- a/src/abnf/grammars/rfc3987.py
+++ b/src/abnf/grammars/rfc3987.py
@@ -89,6 +89,9 @@ iprivate       = %xE000-F8FF / %xF0000-FFFFD / %x100000-10FFFD
     """
 
 
-# ßee https://www.rfc-editor.org/rfc/rfc3987#section-2.2
-for rule in Rule.rules():
-    rule.first_match_alternation = True
+# Every rule here used to be set to `first_match_alternation`, citing
+# RFC 3987 section 2.2.  It had the same effect as the equivalent setting in
+# `rfc3986`, one rule at a time: `ihost` committed to IPv4address on a prefix,
+# so `https://1.2.3.4.in-addr.arpa/` was rejected.  Longest-match alternation
+# attributes a full IPv4 host to IPv4address anyway, by declaration order.
+# See https://github.com/declaresub/abnf/issues/232 .

--- a/tests/test_rfc3986.py
+++ b/tests/test_rfc3986.py
@@ -61,3 +61,53 @@ def test_24_empty_and_relative_paths(rule: str, src: str, alternative: str):
 @pytest.mark.parametrize('src', ['mailto:', 'urn:ietf:rfc:2648', 'http://example.com'])
 def test_24_uri_with_empty_or_rootless_path(src: str):
     assert rfc3986.Rule('URI').parse_all(src).value == src
+
+
+# Issue #232: `host` used to set `first_match_alternation`, citing RFC 3986
+# section 3.2.2.  Under first match the alternation commits to IPv4address on a
+# *prefix*: `1.2.3.4.5` matched `1.2.3.4`, reg-name was never tried, and the
+# whole URI was rejected.  Section 3.2.2 is about attributing a match of the
+# whole host, which longest match already does -- a full IPv4 host ties with
+# reg-name and declaration order breaks the tie.
+@pytest.mark.parametrize(
+    'src',
+    [
+        'http://1.2.3.4.5/',                # four octets then more label
+        'https://1.2.3.4.in-addr.arpa/',    # ordinary reverse-DNS name
+        'http://1.2.3.4.example.com/',
+        'http://256.1.1.1/',                # not an IPv4 address at all
+        'http://1.2.3/',
+        'http://3com.com/',                 # digit-leading reg-name
+    ],
+)
+def test_232_hosts_that_start_like_an_ipv4_address(src: str):
+    assert rfc3986.Rule('URI').parse_all(src).value == src
+
+
+@pytest.mark.parametrize(
+    'src, expected',
+    [
+        ('http://1.2.3.4/', 'IPv4address'),      # section 3.2.2: not reg-name
+        ('http://1.2.3.4:80/x', 'IPv4address'),
+        ('http://1.2.3.4.5/', 'reg-name'),
+        ('http://[::1]:8080/', 'IP-literal'),
+        ('http://example.com/', 'reg-name'),
+    ],
+)
+def test_232_host_is_still_attributed_per_section_3_2_2(src: str, expected: str):
+    """The reason the flag was there in the first place has to keep
+    holding without it."""
+    node = rfc3986.Rule('URI').parse_all(src)
+
+    def find_host(n):
+        if getattr(n, 'name', None) == 'host':
+            return n
+        for child in getattr(n, 'children', None) or ():
+            found = find_host(child)
+            if found:
+                return found
+        return None
+
+    host = find_host(node)
+    assert host is not None
+    assert [c.name for c in host.children] == [expected]

--- a/tests/test_rfc3987.py
+++ b/tests/test_rfc3987.py
@@ -1,3 +1,5 @@
+import pytest
+
 from abnf.grammars import rfc3987
 
 
@@ -8,3 +10,33 @@ def test_ipath_empty():
     src = ""
     node = rfc3987.Rule("ipath-empty").parse_all(src)
     assert node.value == src
+
+
+# Issue #232: every rule in this module used to be set to
+# `first_match_alternation` in a loop, which had the same effect as the
+# equivalent setting in rfc3986 -- `ihost` committed to IPv4address on a
+# prefix, so an IRI whose host merely begins like an IPv4 address was
+# rejected.
+@pytest.mark.parametrize(
+    'src',
+    [
+        'https://1.2.3.4.in-addr.arpa/',
+        'http://1.2.3.4.5/',
+        'https://1.2.3.4.\u4f8b\u3048.jp/',
+    ],
+)
+def test_232_ihosts_that_start_like_an_ipv4_address(src: str):
+    assert rfc3987.Rule('IRI').parse_all(src).value == src
+
+
+@pytest.mark.parametrize(
+    'src',
+    [
+        'http://ex\u00e4mple.com/\u00fcnicode?q=\u00e9#frag',
+        'https://\u4f8b\u3048.jp/\u9053',
+        'https://user:pw@\u4f8b\u3048.jp:8080/\u9053?q=1#f',
+        'http://1.2.3.4/',
+    ],
+)
+def test_232_ordinary_iris_are_unaffected(src: str):
+    assert rfc3987.Rule('IRI').parse_all(src).value == src


### PR DESCRIPTION
Closes #232.

```python
rfc3986.Rule("URI").parse_all("http://1.2.3.4.5/")              # was ParseError
rfc3986.Rule("URI").parse_all("https://1.2.3.4.in-addr.arpa/")  # was ParseError
rfc3987.Rule("IRI").parse_all("https://1.2.3.4.in-addr.arpa/")  # was ParseError
```

`host` set `first_match_alternation`, citing RFC 3986 §3.2.2:

> If host matches the rule for IPv4address, then it should be considered an IPv4 address literal and not a reg-name.

That is a rule about attributing a match of the **whole** host. First match instead commits to `IPv4address` on a **prefix**: `1.2.3.4` of `1.2.3.4.5` matched, `reg-name` was never tried, and the parse failed. RFC 3986's own Appendix B parses with a greedy regex, which never rejects. `rfc3987` applied the same setting to *every* rule in the module, in a loop, so IRIs failed identically.

## Removing it loses nothing

Longest-match alternation already does what §3.2.2 asks: a full IPv4 host ties with `reg-name`, and declaration order breaks the tie toward `IPv4address`. Tests pin that attribution, so the reason the flag existed cannot quietly stop holding:

| `http://…` | host attributed to |
|---|---|
| `1.2.3.4/` | `IPv4address` |
| `1.2.3.4:80/x` | `IPv4address` |
| `1.2.3.4.5/` | `reg-name` |
| `[::1]:8080/` | `IP-literal` |
| `example.com/` | `reg-name` |

## Measured before changing anything

Across a 48-case corpus of URIs and IRIs, flags on vs off:

```
48 cases; 5 changed
  URI|http://1.2.3.4.5/              ParseError@14 -> OK
  URI|https://1.2.3.4.in-addr.arpa/  ParseError@15 -> OK
  IRI|http://1.2.3.4.5/              ParseError@14 -> OK
  IRI|https://1.2.3.4.in-addr.arpa/  ParseError@15 -> OK
  IRI|https://1.2.3.4.例え.jp/        ParseError@15 -> OK
```

Every change is a rejection becoming an acceptance. No input that already parsed changes its value or its parse tree. Parse benchmarks are unmoved, despite longest match now trying all three host alternatives.

## Not a regression from #53

The recent `first_match_alternation` work made that flag reach nested alternations. It is not the cause here — a pre-#53 checkout rejects these inputs identically. Verified before writing the issue.

3,970 tests on Rust, 1,499 on pure Python. The comments left in both modules record what §3.2.2 actually says and what first match did with it, so the next reader does not have to re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
