### PR TITLE
Accept the DMARC records RFC 7489 defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+* `abnf.grammars.rfc7489` accepts the DMARC records RFC 7489 defines, including
+  the one printed in the RFC's own section B.1.1.  `dmarc-record` required the
+  `p` tag and a trailing `";"`, both of which section 6.4 brackets as optional,
+  so `v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com` was rejected --
+  as is most of what is published, since records rarely end in a separator.
+  The rule keeps reading the RFC's fixed sequence as a repetition, which is
+  what its own note about components appearing "in any order" calls for
+  (https://github.com/declaresub/abnf/issues/233).
+
+  The `URI` rule, which this module deliberately narrows to the mailto scheme
+  (section 6.2 supports no other), is now written as a char-val rather than as
+  `%x` literals, so it is case-insensitive as RFC 3986 section 3.1 requires of
+  a scheme.  `MAILTO:` used to be rejected.
+
 * `abnf.grammars.rfc3986` and `abnf.grammars.rfc3987` accept URIs and IRIs they
   used to reject.  `host` set `first_match_alternation`, citing RFC 3986
   section 3.2.2 -- but that section is about attributing a match of the *whole*

--- a/src/abnf/grammars/rfc7489.py
+++ b/src/abnf/grammars/rfc7489.py
@@ -22,7 +22,12 @@ class Rule(_Rule):
 
     ]"""
     grammar: ClassVar[list[str] | str] = [
-        "URI = %x6D %x61 %x69 %x6C %x74 %x6F %x3A addr-spec",
+        # RFC 7489 defines URI as RFC 3986's, but section 6.2 supports only
+        # the mailto scheme, so this narrows it deliberately.  Written as a
+        # char-val rather than as %x6D %x61 ... so that it is
+        # case-insensitive, as RFC 3986 section 3.1 requires of a scheme:
+        # the %x form rejected "MAILTO:".
+        'URI = "mailto:" addr-spec',
         'dmarc-uri = URI [ "!" 1*DIGIT [ "k" / "m" / "g" / "t" ] ]',
         'dmarc-version = "v" *WSP "=" *WSP %x44 %x4d %x41 %x52 %x43 %x31',
         "dmarc-sep = *WSP %x3b *WSP",
@@ -38,5 +43,18 @@ class Rule(_Rule):
         'dmarc-rfmt = "rf"  *WSP "=" *WSP "afrf"',
         # Originaly 'dmarc-percent = "pct" *WSP "=" *WSP 1*3DIGIT'. 'pct=999' is following the grammar but it is wrong
         'dmarc-percent = "pct" *WSP "=" *WSP ( "100" / 1*2DIGIT / "0" )',
-        "dmarc-record = dmarc-version dmarc-sep dmarc-request *(dmarc-sep (dmarc-srequest / dmarc-auri / dmarc-furi / dmarc-aspf / dmarc-adkim / dmarc-aspf / dmarc-ainterval / dmarc-fo / dmarc-percent / dmarc-rfmt)) dmarc-sep",
+        # RFC 7489 section 6.4 writes this as a fixed sequence of optional
+        # components, then notes that "components other than dmarc-version
+        # and dmarc-request may appear in any order" -- so a repetition of
+        # alternatives is the reading that accepts what the prose allows.
+        #
+        # Both the request tag and the trailing separator are optional there,
+        # and were required here: the record printed in RFC 7489 section
+        # B.1.1 was rejected, as is any record without a trailing ";", which
+        # is most of them in practice.  See
+        # https://github.com/declaresub/abnf/issues/233 .
+        "dmarc-tag = dmarc-request / dmarc-srequest / dmarc-auri / dmarc-furi "
+        "/ dmarc-adkim / dmarc-aspf / dmarc-ainterval / dmarc-fo "
+        "/ dmarc-percent / dmarc-rfmt",
+        "dmarc-record = dmarc-version dmarc-sep [ dmarc-tag *(dmarc-sep dmarc-tag) ] [ dmarc-sep ]",
     ]

--- a/tests/test_rfc7489.py
+++ b/tests/test_rfc7489.py
@@ -1,7 +1,7 @@
 import pytest
 
 from abnf.grammars import rfc7489
-from abnf.parser import Source
+from abnf.parser import ParseError, Source
 
 
 def test_valid_dmarc_version():
@@ -147,4 +147,42 @@ def test_valid_dmarc_record(src: Source):
     assert record.parse_all(src)
 
 
+# Issue #233: `dmarc-record` required the `p` tag and a trailing separator,
+# both of which RFC 7489 section 6.4 brackets as optional.  The first record
+# below is the one printed in the RFC's own section B.1.1.
+@pytest.mark.parametrize(
+    'src',
+    [
+        'v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com',
+        'v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com; '
+        'ruf=mailto:auth-reports@example.com',
+        'v=DMARC1; rua=mailto:d@example.com',        # no p tag at all
+        'v=DMARC1; p=none;',                          # trailing separator still allowed
+        'v=DMARC1;',                                  # nothing but the version
+        'v=DMARC1; p=quarantine; pct=50; adkim=s; aspf=r',
+        'v=DMARC1; sp=reject; fo=1:d; rf=afrf; ri=86400',
+    ],
+)
+def test_233_valid_dmarc_records(src: Source):
+    assert rfc7489.Rule('dmarc-record').parse_all(src).value == src
 
+
+@pytest.mark.parametrize(
+    'src',
+    [
+        'v=DMARC1',            # the separator after the version is required
+        'p=none; v=DMARC1;',   # the version must come first
+        'v=DMARC2; p=none;',   # wrong version
+        '',
+    ],
+)
+def test_233_invalid_dmarc_records(src: Source):
+    with pytest.raises(ParseError):
+        rfc7489.Rule('dmarc-record').parse_all(src)
+
+
+@pytest.mark.parametrize('src', ['mailto:d@example.com', 'MAILTO:d@example.com'])
+def test_233_uri_scheme_is_case_insensitive(src: Source):
+    """RFC 3986 section 3.1: the scheme is case-insensitive.  The rule was
+    written with %x literals, which are not."""
+    assert rfc7489.Rule('URI').parse_all(src).value == src


### PR DESCRIPTION
Closes #233.

The record printed in RFC 7489's **own section B.1.1** did not parse:

```python
rfc7489.Rule("dmarc-record").parse_all(
    "v=DMARC1; p=none; rua=mailto:dmarc-feedback@example.com"
)   # was ParseError
```

`dmarc-record` required the `p` tag and a trailing `";"`. Section 6.4 brackets both:

```abnf
dmarc-record = dmarc-version dmarc-sep
               [dmarc-request]
               ...
               [dmarc-sep]
```

The trailing separator is the one that bites: published DMARC records rarely end in one, so this rejected most real input. Erratum 5440 (Verified) confirms only the separator *after the version tag* is mandatory.

## What did not change

The rule still reads the RFC's fixed sequence as a repetition of alternatives — which is what the RFC's own note calls for ("components other than dmarc-version and dmarc-request may appear in any order"), and which the module already did. Only the two optionals move. The duplicated `dmarc-aspf` in that alternation goes with it.

## URI scheme case

`URI` is narrowed to the mailto scheme on purpose — section 6.2 supports no other — but it was written as `%x6D %x61 %x69 ...`, which is case-sensitive, so `MAILTO:` was rejected against RFC 3986 §3.1. As a char-val it is case-insensitive, and the narrowing now carries a comment saying it is deliberate rather than looking like an oversight.

## Tests

| accepted | rejected |
|---|---|
| the RFC's B.1.1 record | `v=DMARC1` (separator after version is required) |
| a record with no `p` tag | `p=none; v=DMARC1;` (version must be first) |
| `v=DMARC1;` alone | `v=DMARC2; p=none;` |
| trailing separator still fine | empty |
| `MAILTO:` and `mailto:` | |

3,983 tests on Rust, 1,512 on pure Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
