### PR TITLE
Correct the record on #244: rfc7405 was not broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,18 @@
 
 ## Unreleased
 
-* `abnf.grammars.rfc7405` can parse `%s` and `%i` char-vals, which is the one
-  thing the module exists for.  Its import list is built by comprehension over
-  every `rfc5234` rule, and that set included `char-val`; imports are applied
-  after the grammar list, so RFC 5234's plain rule replaced the extended one
-  and `%s"abc"` did not parse at all
+* `abnf.grammars.rfc7405` gains a test file.  The module had none, so nothing
+  checked that it could parse the `%s` and `%i` char-vals it exists to define.
+  It always could; the tests now pin it at every level -- `char-val`,
+  `element`, `rule` and `rulelist` -- so a change that breaks the chain fails.
+
+  The ten meta-grammar rules that reach `char-val` are now defined locally,
+  copied from RFC 5234 unchanged, rather than left to resolve through the
+  import chain.  This is behaviour-preserving: the module's import list never
+  contained those names, and 592 generated `rulelist` strings parse identically
+  before and after.  Spelling them out means the module no longer depends on
+  the order in which its import list is computed
   (https://github.com/declaresub/abnf/issues/244).
-
-  Excluding `char-val` from the import is not sufficient: an imported rule
-  refers to the *other* module's rule objects, so `element` -- and everything
-  above it, through the mutual recursion between `element`, `group`, `option`
-  and `alternation` -- would still reach RFC 5234's `char-val`.  Those ten
-  rules are now defined locally, copied from RFC 5234 unchanged, and the rest
-  are still imported.
-
-  The module had no test file, which is how this went unnoticed; it has one
-  now.
 
 * Three smaller grammar transcription errors, each verified against the RFC
   text (https://github.com/declaresub/abnf/issues/237):

--- a/src/abnf/grammars/rfc7405.py
+++ b/src/abnf/grammars/rfc7405.py
@@ -20,9 +20,11 @@ from .misc import load_grammar_rules
 #: the extension would apply to nothing above it.  They are defined
 #: below instead, copied from RFC 5234 unchanged.
 #:
-#: `char-val` itself was in the imported set, which silently replaced
-#: the extended rule with the plain one: `%s"abc"` did not parse at
-#: all.  See https://github.com/declaresub/abnf/issues/244 .
+#: These names never reached the import list in practice -- the
+#: comprehension below is evaluated while `rfc5234` is still being
+#: populated, so it sees only the eleven leaf rules.  Naming them makes
+#: the filter say what it means rather than depend on that timing.
+#: See https://github.com/declaresub/abnf/issues/244 .
 _REDEFINED = frozenset(
     {
         "char-val",

--- a/tests/test_rfc7405.py
+++ b/tests/test_rfc7405.py
@@ -5,11 +5,14 @@ from abnf.parser import ParseError
 
 
 # Issue #244: this module exists to extend RFC 5234's char-val with the
-# case-sensitive (%s) and case-insensitive (%i) forms.  Its import list was
-# built by comprehension over every rfc5234 rule, which included `char-val`,
-# and imports are applied after the grammar list -- so the extended rule was
-# replaced by the plain one and the module could not do the one thing it is
-# for.  It had no test file, which is how that survived.
+# case-sensitive (%s) and case-insensitive (%i) forms, and it had no test
+# file at all -- nothing checked that it could.  It always could; #244 was
+# reported on a misreading of the import comprehension, which looks like it
+# would shadow `char-val` but is evaluated before `rfc5234` holds that name.
+#
+# The tests remain worth having.  They pin the extension at every level, so a
+# change anywhere in the chain from `rulelist` down to `char-val` -- including
+# an import list that really does shadow it -- fails here.
 
 
 def test_244_char_val_is_the_modules_own_rule():


### PR DESCRIPTION
#244 was not a bug. I got the diagnosis wrong, PR #247 shipped on it, and this corrects the record.

## What I checked

The 18 tests added by #247, run against the module as it stood *before* the fix:

```
18 passed in 0.16s
```

And a differential: 592 `rulelist` strings generated from the post-fix module, parsed by the pre-fix module — **0 rejections**. The change was behaviorally inert.

## Where the reasoning went wrong

The import list is built by comprehension over every `rfc5234` rule, and imports are applied after the grammar list. From the source that reads as: `char-val` is in the set, so RFC 5234's plain rule replaces the extended one. I never ran it. At decoration time the comprehension yields eleven names, not twenty-one:

```
bin-val, c-nl, c-wsp, comment, dec-val, defined-as,
hex-val, num-val, prose-val, repeat, rulename
```

`char-val` and the nine rules reaching it are already absent — the comprehension is evaluated before `rfc5234`'s registry holds those names. The claim was about *when* an expression is evaluated, which is exactly what reading source cannot settle.

## What this branch changes

Only prose: the changelog entry, the `_REDEFINED` comment, and the test-module comment, each of which asserted a fix that fixed nothing.

## What #247 is keeping, and why

- **The 18 tests.** The module had no test file. Nothing checked it could parse `%s`/`%i` — the one thing it exists for. They now pin it at `char-val`, `element`, `rule` and `rulelist`, so an import list that *does* shadow it fails here.
- **The ten local definitions.** They are RFC 5234's rules copied unchanged. Naming them drops the dependence on when the comprehension happens to run, which is a real fragility even though nothing was tripping over it.

## Follow-on

This makes #246 more valuable, not less. A loader that reports import collisions would have answered the question in one run instead of by inference from source. And it is why the abnfgen harness is worth building: the current corpus generator walks the *built parser*, so a loader bug is invisible to it by construction — generator and parser share the defect and always agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
