### PR TITLE
Warn when a grammar import overwrites the module's own rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+* The grammar loader warns when an import overwrites a rule the module
+  defines itself.  Imports are applied after the grammar text, so an imported
+  rule replaces a definition of the same name -- which is the intended
+  mechanism, since a module writes a rule it does not own as prose
+  (`token = <token, see [HTTP], Section 5.6.2>`) and lets the import supply
+  the real one.  Nothing distinguished that from an import replacing real
+  grammar by accident, which is how #234 got in and stayed in.  A
+  `GrammarWarning` now marks the difference
+  (https://github.com/declaresub/abnf/issues/246).
+
+  All 21 import collisions across the bundled grammars are the prose pattern,
+  so this is silent today; reintroducing #234's `("atom", rfc5322.Rule("atom"))`
+  makes it fire.  A test asserts no bundled grammar emits it, because a
+  warning nobody looks at would not have caught either bug.
+
 * `abnf.grammars.rfc9051`'s `resp-text-code` accepts its `atom SP text` form.
   The trailing `1*<any TEXT-CHAR except "]">` was left as prose, and a Prose
   parser always raises -- so the optional group could only ever take its empty

--- a/src/abnf/grammars/misc.py
+++ b/src/abnf/grammars/misc.py
@@ -1,8 +1,48 @@
 """Miscellaneous functions."""
 
-from abnf.parser import ABNFGrammarNodeVisitor, ABNFGrammarRule, Rule
+import warnings
+
+from abnf.parser import (
+    ABNFGrammarNodeVisitor,
+    ABNFGrammarRule,
+    GrammarWarning,
+    Prose,
+    Rule,
+)
 
 __all__ = ["load_grammar_rulelist", "load_grammar_rules"]
+
+
+def _apply_imports(cls: type[Rule], imported_rules: list[tuple[str, Rule]]) -> None:
+    """Apply an import list to ``cls``, warning about accidental overwrites.
+
+    Imports are applied after the grammar text, so an imported rule replaces a
+    definition of the same name.  That is the intended mechanism: a module
+    writes a rule it does not own as prose --
+    ``token = <token, see [HTTP], Section 5.6.2>`` -- and lets the import
+    supply the real one.  Replacing anything *other* than prose is an accident,
+    and a silent one: it swaps a working definition for a different grammar's
+    without a word.  See https://github.com/declaresub/abnf/issues/246 .
+
+    Only the top-level definition is examined, because the rust backend's
+    combinators expose no children to walk.  Every import collision in the
+    bundled grammars is prose exactly at the top level, so that is enough.
+    """
+
+    for name, source in imported_rules:
+        existing = cls._obj_map.get((cls, name.casefold()))
+        definition = getattr(existing, "_definition", None)
+        if definition is not None and not isinstance(definition, Prose):
+            origin = type(source).__module__.rsplit(".", 1)[-1]
+            msg = (
+                f'importing "{name}" from {origin} overwrites the definition '
+                f"{cls.__module__.rsplit('.', 1)[-1]} declares for it.  An "
+                "import is meant to fill in a rule written as prose; this one "
+                "replaces real grammar, which is how issue #234 was "
+                "introduced."
+            )
+            warnings.warn(msg, GrammarWarning, stacklevel=3)
+        cls(name, source.definition)
 
 
 def load_grammar_rules(imported_rules: list[tuple[str, Rule]] | None = None):
@@ -22,8 +62,7 @@ def load_grammar_rules(imported_rules: list[tuple[str, Rule]] | None = None):
         for src in cls.grammar:
             cls.create(src)
         if imported_rules:
-            for rule_def in imported_rules:
-                cls(rule_def[0], rule_def[1].definition)
+            _apply_imports(cls, imported_rules)
         return cls
 
     return rule_decorator
@@ -45,8 +84,7 @@ def load_grammar_rulelist(imported_rules: list[tuple[str, Rule]] | None = None):
         visitor.visit(node)
 
         if imported_rules:
-            for rule_def in imported_rules:
-                cls(rule_def[0], rule_def[1].definition)
+            _apply_imports(cls, imported_rules)
         return cls
 
     return rule_decorator

--- a/tests/test_grammar_warning.py
+++ b/tests/test_grammar_warning.py
@@ -1,7 +1,10 @@
+import subprocess
+import sys
 import warnings
 
 import pytest
 
+from abnf.grammars.misc import _apply_imports
 from abnf.parser import GrammarWarning, ParseError, Rule
 
 
@@ -54,3 +57,103 @@ def test_redefinition_keeps_latest_definition():
     assert R("foo").parse_all("b")
     with pytest.raises(ParseError):
         R("foo").parse_all("a")
+
+
+# Issue #246: imports are applied after the grammar text, so an imported rule
+# replaces a definition of the same name.  That is the intended mechanism --
+# a module writes a rule it does not own as prose and lets the import supply
+# the real one -- but nothing distinguished it from an import clobbering real
+# grammar by accident, which is how #234 got in and stayed in.
+def _source_module(rules: str) -> type[Rule]:
+    class Source(Rule):
+        pass
+
+    for line in rules.splitlines():
+        Source.create(line)
+    return Source
+
+
+def test_246_import_over_prose_is_silent():
+    """The legitimate pattern: declare a rule as prose, import the real one."""
+
+    source = _source_module("token = %x61")
+
+    class R(Rule):
+        pass
+
+    R.create("token = <token, defined elsewhere>")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", GrammarWarning)
+        _apply_imports(R, [("token", source("token"))])
+    assert R("token").parse_all("a")
+
+
+def test_246_import_over_real_grammar_warns():
+    source = _source_module("atom = %x61")
+
+    class R(Rule):
+        pass
+
+    R.create("atom = %x62")
+    with pytest.warns(GrammarWarning, match='importing "atom"'):
+        _apply_imports(R, [("atom", source("atom"))])
+
+
+def test_246_import_of_an_undefined_name_is_silent():
+    """Importing a name the module never mentions is the common case."""
+
+    source = _source_module("UTF8-2 = %x61")
+
+    class R(Rule):
+        pass
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", GrammarWarning)
+        _apply_imports(R, [("UTF8-2", source("UTF8-2"))])
+    assert R("UTF8-2").parse_all("a")
+
+
+def test_246_forward_reference_is_not_a_real_definition():
+    """A rule created only by being mentioned has no definition to clobber."""
+
+    source = _source_module("bar = %x61")
+
+    class R(Rule):
+        pass
+
+    R.create("foo = bar")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", GrammarWarning)
+        _apply_imports(R, [("bar", source("bar"))])
+
+
+# A warning nobody looks at would not have caught either bug, so look at it.
+_IMPORT_SWEEP = """
+import pkgutil
+import warnings
+from importlib import import_module
+
+import abnf.grammars
+from abnf.parser import GrammarWarning
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    for _, name, _ in pkgutil.walk_packages(abnf.grammars.__path__):
+        if name == "cors" or name.startswith("rfc"):
+            import_module(f"{abnf.grammars.__name__}.{name}")
+
+print("\\n".join(
+    str(w.message) for w in caught if issubclass(w.category, GrammarWarning)
+))
+"""
+
+
+def test_246_no_bundled_grammar_warns_on_import():
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _IMPORT_SWEEP],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    warned = [line for line in result.stdout.splitlines() if line]
+    assert not warned, f"bundled grammars emit GrammarWarning on import: {warned}"


### PR DESCRIPTION
Closes #246.

Imports are applied after the grammar text, so an imported rule replaces a definition of the same name. That is the mechanism the grammars rely on — a module writes a rule it does not own as prose and lets the import fill it in:

```
token = <token, see [HTTP], Section 5.6.2>      # rfc9111, supplied by import
```

Nothing told that apart from an import replacing real grammar by accident. #234 was exactly that — `("atom", rfc5322.Rule("atom"))` quietly displacing RFC 9051's own `atom = 1*ATOM-CHAR` — and it stayed in because the swap made no sound.

```
importing "atom" from rfc5322 overwrites the definition rfc9051 declares for it.
An import is meant to fill in a rule written as prose; this one replaces real
grammar, which is how issue #234 was introduced.
```

That is the actual output from putting the offending line back on this branch.

## It is quiet today

A census of every import collision in the bundled grammars, taken at the moment of replacement:

| existing definition | count |
|---|---|
| `Prose` | 21 |
| anything else | 0 |

Twenty-one collisions, all the prose pattern. So the warning fires nowhere in the repo, and `test_246_no_bundled_grammar_warns_on_import` asserts it stays that way — a warning nobody looks at would not have caught either bug.

## Top-level check, not a walk

Only the top-level definition is examined. The rust backend's combinators expose no children, so a deep walk would silently do nothing under the default backend — the failure mode where a check reports clean because it cannot see. Prose sits exactly at the top level in all 21 cases, so the shallow check is sufficient and works identically on both backends.

## On #244

The issue lists #244 as the second instance. It was not — see #248; that diagnosis was mine and it was wrong. #234 is the only real occurrence. The case for this warning does not rest on the count, though: it rests on there being no way to answer "did an import overwrite something?" without inferring it from source, which is what produced the bad #244 diagnosis in the first place.

The four unit tests pin both directions — silent over prose, over an undefined name, and over a forward reference that has no definition to clobber; loud over real grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
