### PR TITLE
Document left recursion, and correct three doc claims that were wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+* Documentation corrections and additions prompted by the recent grammar work:
+
+  * Left recursion is now documented at all.  A recursive-descent parser cannot
+    evaluate it, and under longest-match alternation the rule matches *nothing*,
+    not even the alternatives that would succeed alone -- so the symptom is a
+    rule that refuses everything, which reads as a bad grammar rather than an
+    unsupported one.  `how-to/write-your-own-grammar-module` gives the rewrite,
+    and `explanation/alternation-semantics` explains why longest match makes it
+    total.
+  * A prose value raises `ParseError`, not `GrammarError`.
+    `how-to/validate-input` said the latter.  The distinction matters: a prose
+    failure is indistinguishable from a mismatched input, so in an alternation
+    the parse can succeed with the prose rule absent from the tree, which is
+    how #245 survived.
+  * `explanation/alternation-semantics` recommended `first_match_alternation`
+    per rule, citing `rfc3986`'s `host` as the example to follow.  #232 removed
+    exactly that, because under first match the alternation commits to
+    `IPv4address` on a prefix and rejects `1.2.3.4.5` outright.  No bundled
+    grammar uses the flag now.
+  * The import-collision `GrammarWarning` from #246 is documented, in
+    `reference/api` and in the how-to's section on importing rules.
+  * The README says how to regenerate both fuzz corpora, and what the abnfgen
+    one is for.
+
+  Every example added here was executed rather than written from memory.
+
 * The abnfgen corpus generator no longer silently drops samples containing
   surrogates.  It decoded abnfgen's output as strict UTF-8, which refuses
   them -- so grammars admitting the surrogate block were quietly under-tested,

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ Run the test suite (skip the slower fuzz tests with `--ignore=tests/fuzz`):
 pytest --cov-report term-missing --cov=abnf
 ```
 
+`tests/fuzz/` holds two committed corpora, replayed by every run. If you change a
+grammar module, regenerate them:
+
+```console
+python tests/fuzz/gen_corpus.py rfc9051           # Hypothesis, walks the built parser
+python tests/fuzz/gen_abnfgen_corpus.py rfc9051   # abnfgen, reads the grammar text
+```
+
+The second needs [abnfgen](http://www.quut.com/abnfgen/) on your PATH (or `ABNFGEN`
+set to it); CI only replays what is committed. Reading the text rather than the
+built parser is the point — it catches a grammar that did not become the parser it
+describes, which a generator walking that parser cannot.
+
 Pre-commit hooks run ruff, pyright, check-manifest, and tox. Install them once with
 `pre-commit install`. See the *Explanation* and *How-to* docs for working with the
 Rust backend.

--- a/docs/explanation/alternation-semantics.md
+++ b/docs/explanation/alternation-semantics.md
@@ -72,5 +72,29 @@ match, because `path-abempty` is listed first and succeeds immediately
 
 So first match is not a drop-in speedup for a grammar transcribed from an RFC.
 Enable it for a grammar written with ordered choice in mind, or per rule where
-you have checked the alternatives — `abnf.grammars.rfc3986` does the latter for
-`host`, where the RFC's own order is the intended one.
+you have checked every alternative.
+
+No bundled grammar uses it. `abnf.grammars.rfc3986` set it on `host`, citing
+RFC 3986 section 3.2.2, and it was wrong: under first match the alternation
+commits to `IPv4address` on a *prefix*, so `1.2.3.4.5` matched `1.2.3.4`,
+`reg-name` was never tried, and the whole URI was rejected. Section 3.2.2 is
+about attributing a match of the *whole* host, which longest match already
+does — a full IPv4 host ties with `reg-name`, and declaration order breaks the
+tie in `IPv4address`'s favour
+([issue #232](https://github.com/declaresub/abnf/issues/232)).
+
+## Longest match makes left recursion total
+
+Because every alternative is evaluated, a rule that can reach itself in
+leftmost position is always reached — so it matches nothing at all, not even
+the alternatives that would have succeeded on their own:
+
+```text
+list = item / list "," item          ; matches nothing, not even `item`
+```
+
+Recursive descent cannot evaluate that alternative under either setting, but
+first match would at least let a leading `item` through. See
+{doc}`../how-to/write-your-own-grammar-module` for the rewrite. RFC 9051
+contained two such rules
+([issue #252](https://github.com/declaresub/abnf/issues/252)).

--- a/docs/how-to/validate-input.md
+++ b/docs/how-to/validate-input.md
@@ -33,6 +33,26 @@ node, offset = rfc5322.Rule("address").parse("test@example.com and more", 0)
 
 ```{note}
 A `ParseError` carries the parser and offset at which parsing failed. A
-`GrammarError` (a different exception) means the grammar itself is unusable at that
-point — an undefined rule or a prose-value — not that the input was invalid.
+`GrammarError` (a different exception) means the grammar itself is unusable at
+that point — an undefined rule — not that the input was invalid.
+```
+
+```{warning}
+A **prose value** raises `ParseError`, not `GrammarError`. RFC grammars are full
+of prose (`<any CHAR except CTLs>`), and `abnf` cannot implement English: a rule
+containing one always fails, and it fails the same way a mismatched input does.
+
+That is worth knowing because the failure need not surface as a rejection. If
+the rule sits in an alternation, or is optional, some other alternative absorbs
+the input and the parse *succeeds* with the prose rule missing from the tree:
+
+```python
+# RFC 9051 before issue #245: `resp-text-code` ended in a prose value, so
+# `resp-text` fell through to `[text]`, which admits almost anything.
+node = rfc9051.Rule("resp-text").parse_all("[MYCODE some text] hello")
+[child.name for child in node.children]     # ['text'] -- no resp-text-code
+```
+
+Replace prose with the character set it describes. All the bundled grammars do,
+and a test asserts none of them reaches a prose value.
 ```

--- a/docs/how-to/write-your-own-grammar-module.md
+++ b/docs/how-to/write-your-own-grammar-module.md
@@ -44,6 +44,44 @@ Postal.load_grammar(
 than the base `Rule`) so your rules live in their own registry and cannot collide
 with another grammar's.
 
+## Left recursion will not work
+
+`abnf` is a recursive-descent parser, so a rule that can reach itself in
+leftmost position has no base case to reach: it recurses until the stack runs
+out. The failure is reported as a `ParseError`, which makes it look like the
+input was wrong.
+
+```text
+list = item / list "," item          ; do not write this
+```
+
+Under longest-match alternation — the default — this is worse than it looks.
+Every alternative is evaluated, so the recursive one is always reached, and the
+rule matches **nothing at all**, not even the plain `item` that its own first
+alternative admits.
+
+```python
+Rule("list").parse_all("a")          # ParseError, despite `item` matching
+```
+
+Rewrite it to the right-recursive form, which describes the same language:
+
+```text
+list = item *("," item)
+```
+
+Where the repeated part is more than one element, hoist it into its own rule:
+
+```text
+comp      = comp-item *(SP comp-item)
+comp-item = astring / "(" comp ")"
+```
+
+RFCs do write left-recursive rules — RFC 9051 has two, which is
+[issue #252](https://github.com/declaresub/abnf/issues/252) — so transcribing a
+grammar faithfully is not sufficient. If a rule of yours refuses everything
+including its own simplest alternative, this is the first thing to check.
+
 ## Importing rules from another module
 
 Real RFC grammars reuse rules from other RFCs. The bundled grammars do this with the
@@ -79,3 +117,24 @@ The imported rules are stitched into the subclass's registry at class-definition
 time, so `Rule("preference")` can reference `token` and `OWS` as if they were
 defined locally. Browse `abnf.grammars` for more patterns, and see
 {doc}`../reference/bundled-grammars` for the full list.
+
+### An import replaces a rule of the same name
+
+Imports are applied *after* the grammar text, so importing a name your own
+grammar defines replaces your definition with the other module's. That is
+deliberate — it is how a module declares a rule it does not own and lets the
+import supply it:
+
+```text
+token = <token, see [HTTP], Section 5.6.2>        ; filled in by the import
+```
+
+Replacing anything *other* than a prose placeholder is almost always an
+accident, and `abnf` warns about it:
+
+```python
+importing "atom" from rfc5322 overwrites the definition rfc9051 declares for it.
+```
+
+The warning is a `GrammarWarning`. Turn it into an error while developing a
+grammar with `warnings.simplefilter("error", GrammarWarning)`.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -93,8 +93,19 @@ mind that this checks only for the presence of `lparse`, not its signature.
 .. autoexception:: abnf.GrammarWarning
 ```
 
+`GrammarWarning` is raised for a rule redefined by a later `=` (rather than
+extended by `=/`), for two rules whose names differ only in case, and for an
+import that overwrites a definition which is not a prose placeholder — see
+{doc}`../how-to/write-your-own-grammar-module`.
+
 `ParseError.start` is the code-point offset where the parse failed, and is
 identical on both backends.
+
+A **prose value** raises `ParseError`, not `GrammarError`: `abnf` cannot
+implement `<any CHAR except CTLs>`, so a rule containing one always fails, and
+it fails indistinguishably from a mismatched input. In an alternation or an
+optional group that means the parse can succeed with the prose rule simply
+absent from the tree — see {doc}`../how-to/validate-input`.
 
 `ParseError.parser` describes what failed, but *how* it describes it depends on
 the backend: the pure-Python implementation stores the parser object itself,


### PR DESCRIPTION
Yes — one real gap and three claims that were wrong. All found by checking the docs against what the code now does, and every example here was executed before being written down.

## The gap: left recursion was documented nowhere

A user who writes it gets a rule that refuses everything, which reads as a bad grammar rather than an unsupported construct:

```python
Rule("list").parse_all("a")     # ParseError at 0, despite `item` matching "a"
```

Longest-match alternation is what makes it total — every alternative is evaluated, so the recursive one is always reached and takes the working alternatives down with it. `how-to/write-your-own-grammar-module` now gives the rewrite (including the hoisted form for multi-element repeats), and `explanation/alternation-semantics` explains why the default setting makes it worse. RFC 9051 shipped two such rules (#252), so "transcribe the RFC faithfully" is not sufficient advice.

## Three claims that were wrong

**`validate-input` said a prose value raises `GrammarError`.** It raises `ParseError`:

```python
R.create("a = <some prose>")
R("a").parse_all("x")           # ParseError: Prose: 0
```

The distinction is the whole reason #245 survived. A prose failure is indistinguishable from a mismatched input, so in an alternation or an optional group the parse *succeeds* with the prose rule simply absent from the tree. Now documented as a warning, with the `resp-text-code` case as the example.

**`alternation-semantics` recommended `first_match_alternation` per rule, and named `rfc3986`'s `host` as the example to follow.** #232 removed exactly that setting, because under first match the alternation commits to `IPv4address` on a *prefix* — `1.2.3.4.5` matched `1.2.3.4`, `reg-name` was never tried, and the URI was rejected. The doc was recommending the bug.

Swept the tree to be sure of the replacement text: **no bundled grammar sets the flag at all** any more, at class or rule level. Section 3.2.2's attribution requirement is met by longest match on its own — a full IPv4 host ties with `reg-name` and declaration order breaks the tie — which I verified rather than asserted:

```python
rfc3986.Rule("URI").parse_all("http://1.2.3.4.5/")   # parses
# and http://1.2.3.4/ still attributes host as ['IPv4address']
```

**The import-collision `GrammarWarning` from #246 was undocumented**, in both `reference/api` and the how-to's section on importing rules — including how to turn it into an error while developing a grammar.

## Also

`reference/api` now says what each `GrammarWarning` case is, and the README says how to regenerate both fuzz corpora and what the abnfgen one is for — a contributor changing a grammar had no way to know that from the repo.

Sphinx builds clean, no warnings, all cross-references resolve. Full suite 5,329 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
