### PR TITLE
Read the defined-as operator from its literal, not from stripped text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+* A comment inside `defined-as` no longer turns `=` into `=/`.  RFC 5234
+  section 4 has `defined-as = *c-wsp ("=" / "=/") *c-wsp`, and `c-wsp` reaches
+  `comment` by way of `c-nl`, so a comment may sit on either side of the
+  operator and forms part of that node's span.  The visitor returned the span
+  stripped, which removes whitespace but not comment text, so the result
+  compared unequal to `"="` and took the `=/` branch: a new rule raised a bare
+  `AttributeError`, and a redefinition silently kept its earlier definition
+  alive with no `GrammarWarning`
+  (https://github.com/declaresub/abnf/issues/257).
+
+  The operator is now read from the `defined-as` node's literal child.
+  Searching the span for `"=/"` would not do, since a comment may contain that
+  text -- `foo ;see =/ below` is a plain `=` rule, and there is a test for it.
+
 * Documentation corrections and additions prompted by the recent grammar work:
 
   * Left recursion is now documented at all.  A recursive-descent parser cannot

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -1729,8 +1729,24 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
 
     @staticmethod
     def visit_defined_as(node: Node):
-        """Returns defined-as operator."""
-        return node.value.strip()
+        """Returns the defined-as operator, ``"="`` or ``"=/"``.
+
+        RFC 5234 section 4 has ``defined-as = *c-wsp ("=" / "=/") *c-wsp``,
+        and ``c-wsp`` reaches ``comment`` by way of ``c-nl`` -- so a comment
+        may sit on either side of the operator and is part of this node's
+        span.  Stripping the span only removes whitespace, which left the
+        comment text attached and made the result compare unequal to both
+        operators.
+
+        Scanning the span for ``"=/"`` would be no better, since a comment may
+        contain that text: ``foo ;see =/ below`` is a plain ``=`` rule.  The
+        operator is the one literal among the children, so take it from there.
+        """
+
+        return next(
+            (child.value for child in node.children if child.name == "literal"),
+            node.value.strip(),
+        )
 
     def visit_element(self, node: Node):
         """Creates a parser object from element node."""

--- a/tests/test_grammar_warning.py
+++ b/tests/test_grammar_warning.py
@@ -157,3 +157,68 @@ def test_246_no_bundled_grammar_warns_on_import():
     )
     warned = [line for line in result.stdout.splitlines() if line]
     assert not warned, f"bundled grammars emit GrammarWarning on import: {warned}"
+
+
+# Issue #257: RFC 5234 section 4 has `defined-as = *c-wsp ("=" / "=/") *c-wsp`,
+# and c-wsp reaches `comment` through c-nl -- so a comment may sit on either
+# side of the operator and is part of the defined-as span.  `visit_defined_as`
+# returned that span stripped, which removes whitespace but not comment text,
+# so the result compared unequal to "=" and fell into the "=/" branch.
+def test_257_comment_before_equals_defines_a_new_rule():
+    class R(Rule):
+        pass
+
+    R.load_grammar('bar ;note\r\n = "x"\r\n')
+    assert R('bar').parse_all('x').value == 'x'
+
+
+def test_257_comment_before_equals_is_still_a_redefinition():
+    class R(Rule):
+        pass
+
+    R.load_grammar('foo = "x"\r\n')
+    with pytest.warns(GrammarWarning, match="redefines 'foo'"):
+        R.load_grammar('foo ;note\r\n = "y"\r\n')
+    # '=' discards the earlier definition; '=/' would have kept it.
+    assert R('foo').parse_all('y').value == 'y'
+    with pytest.raises(ParseError):
+        R('foo').parse_all('x')
+
+
+def test_257_comment_containing_the_other_operator_is_not_the_operator():
+    """Scanning the span for '=/' would misread this as an incremental rule."""
+
+    class R(Rule):
+        pass
+
+    R.load_grammar('foo = "x"\r\n')
+    with pytest.warns(GrammarWarning):
+        R.load_grammar('foo ;see =/ below\r\n = "y"\r\n')
+    with pytest.raises(ParseError):
+        R('foo').parse_all('x')
+
+
+def test_257_comment_after_the_operator_too():
+    class R(Rule):
+        pass
+
+    R.load_grammar('baz =;note\r\n "x"\r\n')
+    assert R('baz').parse_all('x').value == 'x'
+
+
+def test_257_real_incremental_alternative_still_works():
+    class R(Rule):
+        pass
+
+    R.load_grammar('q = "x"\r\nq =/ "y"\r\n')
+    assert R('q').parse_all('x').value == 'x'
+    assert R('q').parse_all('y').value == 'y'
+
+
+def test_257_incremental_alternative_with_a_comment():
+    class R(Rule):
+        pass
+
+    R.load_grammar('q = "x"\r\nq ;note\r\n =/ "y"\r\n')
+    assert R('q').parse_all('x').value == 'x'
+    assert R('q').parse_all('y').value == 'y'


### PR DESCRIPTION
Closes #257.

```python
class A(Rule): pass
A.load_grammar('bar ;note\r\n = "x"\r\n')
# before: AttributeError: 'A' object has no attribute '_definition'
# after:  defines bar, as the ABNF says
```

RFC 5234 section 4:

```
defined-as = *c-wsp ("=" / "=/") *c-wsp
c-wsp      = WSP / (c-nl WSP)
c-nl       = comment / CRLF
```

so a comment may sit on either side of the operator, and it forms part of the `defined-as` span. The grammar parsed such rules correctly all along — the **visitor** misread them:

```python
return node.value.strip()      # ' ;note\r\n = '  ->  ';note\r\n ='
```

`strip()` removes whitespace, not comment text, so the result compared unequal to `"="` and fell through to the `=/` branch.

## The quiet symptom is the worse one

A new rule crashed loudly. A *redefinition* did not:

```python
C.load_grammar('foo = "x"\r\n')
C.load_grammar('foo ;note\r\n = "y"\r\n')     # a plain '=' redefinition
C('foo').parse_all('x')                        # still parses -- it should not
```

The earlier definition stayed live with `=/` semantics, and the `GrammarWarning` that exists to report exactly this was suppressed.

## Why not just look for "=/" in the span

Because a comment can contain it:

```
foo ;see =/ below
    = "x"
```

is a plain `=` rule. Text-scanning gets that backwards. The operator is the sole `literal` child of the `defined-as` node, so it is read from there — and there is a test for the comment-containing-`=/` case specifically.

## Coverage

Six tests; four fail on the parent commit and all six pass here. The two that pass either way are the genuine `=/` cases, which is the point — the fix must not disturb them. Verified on both backends.

Both backends were affected, since the visitor is the shared Python bootstrap. That is why 109,100 cross-backend differential cases never saw this: they agree, wrongly. It needed a reader with RFC 5234 open, which is what this review round was for.

Full suite 5,335 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
