### PR TITLE
Refuse first_match_alternation assigned on a grammar class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@
 
   ABNF rule names are case-insensitive, so both spellings always named one
   rule; where a visitor defines both, the lowercase one still wins, as before.
+* Assigning `first_match_alternation` on a grammar class raises
+  `AttributeError` instead of being accepted and ignored.  The setting is
+  implemented by a descriptor serving both supported spellings; assigning it on
+  a class object -- rather than in a class body -- dropped a plain `bool` into
+  the class dict and shadowed that descriptor.  Nothing read the bool, so the
+  attribute reported a setting the parser was not using, and the documented
+  per-rule spelling then failed silently for that grammar from then on
+  (https://github.com/declaresub/abnf/issues/258).
+
+  Both supported spellings are unchanged.  A non-`bool` in the class body is
+  refused too, with `TypeError`: it shadows the descriptor exactly as a stray
+  assignment does.
+
+  `Rule` now has a metaclass, which is what makes the assignment interceptable.
+  One consequence worth knowing: a subclass combining `Rule` with a class whose
+  metaclass is unrelated -- `class R(Rule, abc.ABC)` -- now raises a metaclass
+  conflict.  Combining with `typing.Generic` and ordinary bases is unaffected.
 
 * Defining a core rule from a grammar module now raises `GrammarError`
   instead of replacing it for every grammar in the process.  The RFC 5234

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,6 +15,23 @@ class MyGrammar(Rule):
     first_match_alternation = True
 ```
 
+```{important}
+It must be set **in the class body**, not assigned on the class afterwards:
+
+    MyGrammar.first_match_alternation = True     # AttributeError
+
+That assignment would replace the descriptor implementing this setting with a
+plain `bool`. The flag would then read back `True` while the parser carried on
+using longest match, and the per-rule spelling below would stop working for
+that grammar entirely. Since 2.9.0 it is refused rather than accepted and
+ignored ([issue #258](https://github.com/declaresub/abnf/issues/258)).
+
+To decide the setting at run time, put the value in the class body:
+
+    class MyGrammar(Rule):
+        first_match_alternation = use_first_match
+```
+
 Set in a class body it becomes the grammar's default, applied to every
 alternation built for it — including alternations nested inside a group or
 repetition, which a rule does not otherwise expose.

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -631,7 +631,42 @@ class _FirstMatchAlternation:
         instance._set_first_match_alternation(value)
 
 
-class Rule:
+class _RuleMeta(type):
+    """Metaclass for :class:`Rule`, guarding one attribute.
+
+    ``first_match_alternation`` is a descriptor.  Assigning to it *on a class
+    object* -- ``MyGrammar.first_match_alternation = True``, rather than in the
+    class body -- is an ordinary ``type.__setattr__``, which drops a plain
+    ``bool`` into the class dict and shadows the descriptor.  Nothing then
+    reads that bool: alternations are built from ``_first_match_default``,
+    which is untouched.  So the attribute reported a setting the parser was not
+    using, and, worse, the documented per-rule spelling
+    (``rule.first_match_alternation = True``) stopped working for that class
+    from then on, silently, because it too went to a plain dict rather than
+    through the descriptor.
+
+    Refusing the assignment leaves the descriptor in place, so both supported
+    spellings keep working and neither can be quietly disabled.
+    See https://github.com/declaresub/abnf/issues/258 .
+    """
+
+    def __setattr__(cls, name: str, value: typing.Any) -> None:
+        if name == "first_match_alternation":
+            msg = (
+                "first_match_alternation cannot be assigned on a grammar class. "
+                "Set it in the class body, before the grammar is loaded:\n\n"
+                "    class MyGrammar(Rule):\n"
+                "        first_match_alternation = True\n\n"
+                "or on one rule: MyGrammar('rulename').first_match_alternation = "
+                "True.  Assigning it here would replace the descriptor that "
+                "implements both, leaving the flag reading back True while the "
+                "parser went on using longest match."
+            )
+            raise AttributeError(msg)
+        super().__setattr__(name, value)
+
+
+class Rule(metaclass=_RuleMeta):
     """A parser generated from an ABNF rule.
 
     To create a Rule object, use Rule.create.
@@ -757,6 +792,14 @@ class Rule:
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
         super().__init_subclass__(**kwargs)
         raw = cls.__dict__.get("first_match_alternation")
+        if raw is not None and not isinstance(raw, bool):
+            msg = (
+                "first_match_alternation must be True or False, not "
+                f"{type(raw).__name__}.  A value of any other type is left "
+                "shadowing the descriptor that implements the setting, which "
+                "would disable it for this grammar without saying so."
+            )
+            raise TypeError(msg)
         if isinstance(raw, bool):
             cls._first_match_default = raw
             # Restore the inherited property: a plain bool left in the

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2289,3 +2289,66 @@ def test_259_an_unrelated_node_is_still_skipped():
 
     node = rfc3986.Rule('URI').parse_all('http://example.com/')
     assert V().visit(node) is None
+# Issue #258: `first_match_alternation` is a descriptor serving both supported
+# spellings.  Assigning it on a class object -- rather than in a class body --
+# was an ordinary type.__setattr__ that dropped a bool into the class dict and
+# shadowed it.  Nothing read that bool, so the attribute reported a setting the
+# parser was not using; and the documented per-rule spelling silently stopped
+# working for that class from then on, because it too went to a plain dict.
+def test_258_assigning_on_the_class_object_is_refused():
+    class M(Rule):
+        pass
+
+    M.create('r = "a" / "ab"')
+    with pytest.raises(AttributeError, match='cannot be assigned'):
+        M.first_match_alternation = True
+
+
+def test_258_the_message_names_both_supported_spellings():
+    class M(Rule):
+        pass
+
+    with pytest.raises(AttributeError) as excinfo:
+        M.first_match_alternation = True
+    message = str(excinfo.value)
+    assert 'class body' in message
+    assert "first_match_alternation = True" in message
+
+
+def test_258_class_body_spelling_still_works():
+    class N(Rule):
+        first_match_alternation = True
+
+    N.create('r = "a" / "ab"')
+    # First match takes "a" and stops; longest match would consume "ab".
+    assert N('r').parse('ab', 0)[1] == 1
+
+
+def test_258_per_rule_spelling_still_works():
+    class P(Rule):
+        pass
+
+    P.create('r = "a" / "ab"')
+    assert P('r').parse('ab', 0)[1] == 2
+    P('r').first_match_alternation = True
+    assert P('r').parse('ab', 0)[1] == 1
+    P('r').first_match_alternation = False
+    assert P('r').parse('ab', 0)[1] == 2
+
+
+def test_258_a_non_bool_in_the_class_body_is_refused():
+    """It shadows the descriptor exactly as a stray assignment does."""
+    with pytest.raises(TypeError, match='must be True or False'):
+
+        class Q(Rule):
+            first_match_alternation = 1  # pyright: ignore[reportAssignmentType]
+
+
+def test_258_other_class_attributes_are_unaffected():
+    class R2(Rule):
+        pass
+
+    R2.grammar = ['r = "a"']
+    assert R2.grammar == ['r = "a"']
+    R2.create('r = "a"')
+    assert R2('r').parse_all('a').value == 'a'


### PR DESCRIPTION
Closes #258.

```python
M.first_match_alternation = True     # before: accepted, and ignored
M.first_match_alternation            # True   -- while the parser used longest match
```

The setting is implemented by a descriptor serving both supported spellings. Assigning it *on a class object*, rather than in a class body, is an ordinary `type.__setattr__` that drops a plain `bool` into the class dict and shadows the descriptor. Nothing reads that bool — alternations are built from `_first_match_default` — so the flag reported a setting the parser was not using.

The second half is worse, and is squarely inside the documented contract:

```python
r = M('r')
r.first_match_alternation = True     # the documented per-rule spelling
r.first_match_alternation            # True
M('r').parse('ab', 0)                # ('ab', 2) -- still longest match
```

With the descriptor shadowed, the per-rule write lands in an instance dict instead of going through `__set__`. So one stray assignment silently disabled the per-rule API for that grammar, permanently.

Now `AttributeError`, with a message naming both supported spellings.

## Also refused: a non-`bool` in the class body

`first_match_alternation = 1` fails the `isinstance(raw, bool)` check in `__init_subclass__` and was left shadowing the descriptor — identical silent breakage by a different route. Now `TypeError`.

## The trade-off, stated plainly

Intercepting assignment on a class object requires a metaclass, so `Rule` has one now. **This is a behaviour change**: a subclass combining `Rule` with a class whose metaclass is unrelated now raises a metaclass conflict.

```python
class R(Rule, abc.ABC): ...     # TypeError: metaclass conflict
```

Combining with `typing.Generic` and with ordinary bases is unaffected — verified both.

Deriving `_RuleMeta` from `ABCMeta` would remove even that, but it puts `ABCMeta.__call__` on every `Rule(name)`, which is the rule-lookup path and hot. Grammar classes are concrete namespaces built by decorators, so inheriting `ABC` alongside one is not a pattern this library has any reason to support. I judged the cost worth it; say if you would rather have the compatibility and take the slower construction, and I will swap it.

## Coverage

Six tests: the refusal, the message content, both supported spellings still working (including flipping back), the non-`bool` class-body case, and one confirming other class attributes still assign normally. Three fail on the parent commit.

Full suite 5,369 passing, pyright clean, docs updated in `reference/configuration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
