### PR TITLE
Clear the last three review findings: empty literal, error contract, memo key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+* An empty literal matches at end of input.  `Literal._lparse_value`
+  guarded with `start < len(source)`, so `""` matched an empty span at every
+  offset *except* `len(source)`: `"a" ""` could not match `"a"` while
+  `"" "a"` could.  RFC 5234's `char-val` admits zero characters, and a
+  zero-length match cannot depend on what follows it
+  (https://github.com/declaresub/abnf/issues/260).
+
+  The check is now `start + len(value) > len(source)`, which says the one
+  thing that matters -- enough source must remain for the whole literal -- and
+  covers the empty case without a special branch.  An offset genuinely past
+  the end still raises, which is what the original M2 regression was about:
+  that fix resolved a rust/Python divergence in favour of the reference
+  without checking the reference against the RFC, and pinned the wrong
+  behaviour in tests.  Both backends changed; the rust unit test that asserted
+  it is updated.
+
+* Two invalid grammars raise `GrammarError` instead of a raw Python exception
+  (https://github.com/declaresub/abnf/issues/261):
+
+  * A num-val past the end of the code-point space -- `%x110000` -- raised
+    `ValueError` from `chr`, naming neither the rule nor the grammar.
+  * `=/` on a rule with no definition raised
+    `AttributeError: no attribute '_definition'`, which reads as a library
+    fault rather than as an invalid grammar.  RFC 5234 section 3.3 allows
+    incremental alternatives only for an already-defined rule.
+
+* The per-parse memo keys on the parser object rather than on `id(self)`.  An
+  id is unique only among live objects, so a `Repetition` freed during a parse
+  could have its address reused and hand its cached matches to a different
+  parser -- reachable only from a custom `Parser` that builds and drops
+  combinators mid-parse, but a latent hazard rather than a trade-off.  Holding
+  the object keeps it alive for exactly as long as the memo, which is the one
+  parse (https://github.com/declaresub/abnf/issues/262).
+
 * `NodeVisitor` dispatch is case-insensitive, so `visit_URI` runs.  `visit`
   looked the node name up casefolded while the dispatch table was keyed on the
   method-name suffix verbatim, so a method named for the rule as its grammar

--- a/packages/abnf-rust/rust/core/src/literal.rs
+++ b/packages/abnf-rust/rust/core/src/literal.rs
@@ -126,14 +126,17 @@ impl Literal {
                 }
             }
             LiteralKind::String { value, pattern } => {
-                // Mirror Python's `if start < len(source)` guard (see
-                // `_lparse_value`), which raises even for an empty
-                // literal at EOF.  Without it the length check below
-                // would let a zero-length pattern match at any
-                // out-of-range start.
-                if start >= source.len() {
-                    return Err(self.parse_error(start));
-                }
+                // Enough source must remain for the whole literal.  This
+                // one check covers both cases: a non-empty literal needs
+                // room, and a zero-length one needs only `start <=
+                // source.len()`, which is what `end > source.len()` says
+                // when `plen` is 0.
+                //
+                // There used to be a `start >= source.len()` guard above
+                // this, mirroring Python's, which also refused a
+                // zero-length literal at end of input -- so `""` matched
+                // everywhere except there.  See
+                // https://github.com/declaresub/abnf/issues/260 .
                 let plen = value.len();
                 let end = start + plen;
                 if end > source.len() {
@@ -210,11 +213,22 @@ mod tests {
         assert!(lit.lparse(&[0xD800, 0x62], 0).is_err());
     }
 
+    /// #260: a zero-length literal matches the empty string wherever the
+    /// source reaches, end of input included -- but not past it.
     #[test]
-    fn empty_literal_raises_at_eof() {
+    fn empty_literal_matches_at_eof_but_not_beyond() {
         let lit = Literal::string("", false);
-        assert!(lit.lparse(&[], 0).is_err());
-        assert!(lit.lparse(&cps("x"), 0).is_ok());
+        assert!(lit.lparse(&[], 0).is_ok(), "empty source, offset 0");
+        assert!(lit.lparse(&cps("x"), 0).is_ok(), "start of input");
+        assert!(lit.lparse(&cps("x"), 1).is_ok(), "end of input");
+        assert!(lit.lparse(&cps("x"), 2).is_err(), "past end of input");
+        assert!(lit.lparse(&[], 1).is_err(), "past end of empty source");
+
+        // A non-empty literal still needs room for all of itself.
+        let lit = Literal::string("ab", false);
+        assert!(lit.lparse(&cps("ab"), 0).is_ok());
+        assert!(lit.lparse(&cps("a"), 0).is_err());
+        assert!(lit.lparse(&cps("ab"), 2).is_err());
     }
 
     #[test]

--- a/src/abnf/_parser_python.py
+++ b/src/abnf/_parser_python.py
@@ -146,7 +146,13 @@ ParseCacheValue = list[Match] | MatchSet | _CachedParseError
 # 29.9ns vs 34.6ns), and it isolates asyncio tasks as well as threads.  Only
 # `Rule.parse` ever writes it -- never a generator, whose `set` would leak into
 # the caller's context between yields.
-_ParseMemo = tuple[Source, dict[tuple[int, int], ParseCacheValue]]
+#: Keyed on ``(parser, start)``.  The parser is the object itself rather than
+#: its ``id``: an id is unique only among live objects, so a parser freed
+#: mid-parse could have its address reused and inherit the dead one's entries
+#: (issue #262).  Holding it keeps it alive for exactly the life of the memo,
+#: which is one ``Rule.parse`` call.
+_ParseMemoKey = tuple[object, int]
+_ParseMemo = tuple[Source, dict[_ParseMemoKey, ParseCacheValue]]
 _parse_memo: contextvars.ContextVar[_ParseMemo | None] = contextvars.ContextVar(
     "abnf_parse_memo", default=None
 )
@@ -413,7 +419,12 @@ class Repetition:
         ctx = _parse_memo.get()
         memo = ctx[1] if ctx is not None and ctx[0] is source else {}
 
-        cache_key = (id(self), start)
+        # Key on the object, not `id(self)`: an id is unique only among live
+        # objects, so a `Repetition` freed mid-parse could have its address
+        # reused and hand its cached matches to a different parser.  Holding
+        # the object keeps it alive for exactly as long as the memo, which is
+        # this one parse.  See https://github.com/declaresub/abnf/issues/262 .
+        cache_key = (self, start)
         cached_matchset = memo.get(cache_key)
         if cached_matchset is not None:
             if isinstance(cached_matchset, _CachedParseError):
@@ -574,20 +585,27 @@ class Literal:
 
     def _lparse_value(self, source: str, start: int) -> Matches:
         """Parse source when self.value represents a literal."""
-        # we check position to ensure that the case pattern = '' and start >= len(source)
-        # is handled correctly.
-        if start < len(source):
-            src = source[start : start + len(self.value)]
-            match = src if self.case_sensitive else _ascii_fold(src)
-            if match == self.pattern:
-                yield Match(
-                    [typing.cast(Node, LiteralNode(src, start, len(src)))],
-                    start + len(src),
-                )
-            else:
-                raise ParseError(self, start)
-        else:
+        # Enough source must remain for the whole literal.  Slicing would not
+        # say so on its own: `source[start:start + n]` silently returns a short
+        # string past the end, and for a zero-length literal it returns `''`
+        # at *any* start, however far out of range.
+        #
+        # The guard used to be `start < len(source)`, which also refused a
+        # zero-length literal at end of input -- so `""` matched at every
+        # offset except `len(source)`, and `"a" ""` could not match `"a"`
+        # while `"" "a"` could.  RFC 5234's char-val admits zero characters,
+        # and a zero-length match cannot depend on what follows it.
+        # See https://github.com/declaresub/abnf/issues/260 .
+        if start + len(self.value) > len(source):
             raise ParseError(self, start)
+        src = source[start : start + len(self.value)]
+        match = src if self.case_sensitive else _ascii_fold(src)
+        if match != self.pattern:
+            raise ParseError(self, start)
+        yield Match(
+            [typing.cast(Node, LiteralNode(src, start, len(src)))],
+            start + len(src),
+        )
 
     def __str__(self):
         # str(self.value) handles the case value == tuple.
@@ -1748,7 +1766,19 @@ class NumValVisitor(NodeVisitor):
     @staticmethod
     def _decode_bytes(data: str, base: int) -> str:
         """Decodes num-val byte data. Intended to be private."""
-        return chr(int(data, base=base))
+        value = int(data, base=base)
+        # `chr` raises ValueError past U+10FFFF, which reaches the caller as a
+        # builtin error naming neither the rule nor the grammar.  A num-val
+        # outside the code-point space is a grammar error like any other.
+        # See https://github.com/declaresub/abnf/issues/261 .
+        if value > 0x10FFFF:
+            prefix = {2: "%b", 10: "%d", 16: "%x"}.get(base, "%")
+            msg = (
+                f"{prefix}{data} is not a Unicode code point: values run to "
+                "%x10FFFF."
+            )
+            raise GrammarError(msg)
+        return chr(value)
 
 
 class ABNFGrammarNodeVisitor(NodeVisitor):
@@ -1942,6 +1972,19 @@ class ABNFGrammarNodeVisitor(NodeVisitor):
             rule.definition = elements
             rule._alternations = tuple(self._alternations)
         else:
+            # '=/' adds to a definition, so there must be one.  Reading it
+            # unguarded surfaced as `AttributeError: no attribute
+            # '_definition'`, which reads as a library fault rather than as
+            # "this grammar is wrong".  RFC 5234 section 3.3 allows
+            # incremental alternatives only for an already-defined rule.
+            # See https://github.com/declaresub/abnf/issues/261 .
+            if getattr(rule, "_definition", None) is None:
+                msg = (
+                    f"rule {rule_name!r} has no definition to add to: '=/' adds "
+                    "an alternative to an existing rule (RFC 5234 section 3.3). "
+                    "Use '=' to define it."
+                )
+                raise GrammarError(msg)
             # '=/' keeps the earlier definition as one arm, so its
             # alternations stay live and stay configurable.
             previous = rule._alternation_parsers()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1315,32 +1315,53 @@ def test_m1_callback_parser_still_treats_parse_error_as_backtrack():
 
 
 # ---------------------------------------------------------------------------
-# M2 regression: `Literal('')` must raise `ParseError` when invoked at a
-# position past the end of source.  The pure-Python reference checks
-# `start < len(source)` before considering any match (so even an empty
-# literal cannot match at EOF); the Rust fast path skipped that check
-# whenever `plen == 0`, silently matching the empty string at EOF.
+# `Literal('')` must raise `ParseError` when invoked at a position *past* the
+# end of source, and must match everywhere the source reaches, end of input
+# included.
+#
+# The original M2 regression was real: the rust fast path skipped the bounds
+# check whenever `plen == 0`, so an empty literal matched at any offset at all.
+# The fix made rust mirror the pure-Python guard `start < len(source)` -- but
+# that guard was itself wrong, refusing an empty literal at EOF, which is a
+# legitimate position rather than an out-of-range one.  So `""` matched at
+# every offset except `len(source)`, and `"a" ""` could not match `"a"` while
+# `"" "a"` could.
+#
+# Resolving a backend divergence in favour of the reference, without checking
+# the reference against RFC 5234, is what pinned it.  See issue #260.
 # ---------------------------------------------------------------------------
 
 
-def test_m2_empty_literal_raises_at_eof_empty_source():
+def test_260_empty_literal_matches_at_eof_empty_source():
     parser = Literal("")
-    with pytest.raises(ParseError):
-        next(parser.lparse("", 0))
+    assert next(parser.lparse("", 0)).start == 0
 
 
-def test_m2_empty_literal_raises_at_eof_nonempty_source():
+def test_260_empty_literal_matches_at_eof_nonempty_source():
     parser = Literal("")
-    with pytest.raises(ParseError):
-        next(parser.lparse("abc", 3))
+    assert next(parser.lparse("abc", 3)).start == 3
 
 
-def test_m2_empty_literal_matches_inside_source():
-    """Sanity check: empty literal does match when start is strictly
-    inside the source (Python's `start < len(source)` is true)."""
+def test_260_empty_literal_matches_inside_source():
     parser = Literal("")
     match = next(parser.lparse("abc", 1))
     assert match.start == 1  # empty literal advances nothing
+
+
+@pytest.mark.parametrize(("source", "start"), [("", 1), ("abc", 4), ("abc", 99)])
+def test_m2_empty_literal_still_raises_past_end_of_source(source: str, start: int):
+    """The M2 protection that mattered: an offset beyond the source is out of
+    range, and a zero-length pattern must not match there."""
+    parser = Literal("")
+    with pytest.raises(ParseError):
+        next(parser.lparse(source, start))
+
+
+@pytest.mark.parametrize(("source", "start"), [("a", 0), ("ab", 1), ("", 0)])
+def test_260_non_empty_literal_still_needs_room(source: str, start: int):
+    parser = Literal("ab")
+    with pytest.raises(ParseError):
+        next(parser.lparse(source, start))
 
 
 def test_h5_left_recursive_grammar_is_catchable_not_segfault():
@@ -2352,3 +2373,75 @@ def test_258_other_class_attributes_are_unaffected():
     assert R2.grammar == ['r = "a"']
     R2.create('r = "a"')
     assert R2('r').parse_all('a').value == 'a'
+
+
+# Issue #261: two grammar-level mistakes escaped as raw Python exceptions.
+@pytest.mark.parametrize(
+    'grammar',
+    ['r = %x110000', 'r = %x7FFFFFFF', 'r = %d1114112', 'r = %b1000000000000000000000'],
+)
+def test_261_num_val_beyond_the_code_point_space(grammar: str):
+    """`chr` raised ValueError, naming neither the rule nor the grammar."""
+
+    class R(Rule):
+        pass
+
+    with pytest.raises(GrammarError, match='not a Unicode code point'):
+        R.create(grammar)
+
+
+@pytest.mark.parametrize('grammar', ['r = %x10FFFF', 'r = %x41', 'r = %d1114111'])
+def test_261_the_top_of_the_range_is_still_valid(grammar: str):
+    class R(Rule):
+        pass
+
+    R.create(grammar)
+    assert R('r').definition is not None
+
+
+def test_261_incremental_alternative_needs_an_existing_definition():
+    """RFC 5234 section 3.3.  Was a bare AttributeError."""
+
+    class R(Rule):
+        pass
+
+    with pytest.raises(GrammarError, match="no definition to add to"):
+        R.create('nope =/ "a"')
+
+
+def test_261_incremental_alternative_still_works_when_defined():
+    class R(Rule):
+        pass
+
+    R.create('q = "x"')
+    R.create('q =/ "y"')
+    assert R('q').parse_all('x').value == 'x'
+    assert R('q').parse_all('y').value == 'y'
+
+
+# Issue #262: the per-parse memo keyed on `id(self)`, and an id is unique only
+# among live objects -- a Repetition freed mid-parse could have its address
+# reused and hand its cached matches to a different parser.
+def test_262_memo_keys_on_the_object_not_its_address():
+    import pathlib
+
+    import abnf._parser_python as reference
+
+    # Read the file rather than inspect the class: `abnf.parser` patches
+    # backend classes onto this module, so under the rust backend
+    # `reference.Repetition` is not the pure-Python one.
+    source = pathlib.Path(reference.__file__).read_text(encoding='utf-8')
+    assert 'cache_key = (self, start)' in source
+    assert 'cache_key = (id(self), start)' not in source
+
+
+def test_262_repetition_results_are_still_correct_and_cached():
+    class R(Rule):
+        pass
+
+    R.create('r = 1*"ab"')
+    assert R('r').parse_all('ababab').value == 'ababab'
+    # Same rule, different sources: nothing may carry over between parses.
+    assert R('r').parse_all('ab').value == 'ab'
+    with pytest.raises(ParseError):
+        R('r').parse_all('abx')


### PR DESCRIPTION
Closes #260. Closes #261. Closes #262.

The last three findings from the Python review round, all low severity.

## #260 — an empty literal matched everywhere except end of input

```python
G.create('el = "a" ""')
G('el').parse_all('a')     # before: ParseError.  "" would not match at EOF.
G.create('el2 = "" "a"')
G('el2').parse_all('a')    # 'a' -- a leading empty literal was fine
```

The guard was `start < len(source)`, so a zero-length terminal matched at every offset *except* `len(source)`. RFC 5234's `char-val` admits zero characters, and a zero-length match cannot depend on what follows it.

Now one condition — `start + len(value) > len(source)` — which says the only thing that matters, enough source must remain for the whole literal, and covers the empty case with no special branch. An offset genuinely past the end still raises.

**Why this was pinned in tests.** The original M2 regression was real: the rust fast path skipped the bounds check whenever `plen == 0`, matching an empty literal at *any* offset. The fix made rust mirror Python's guard — but that guard was itself wrong. A backend divergence was resolved in favour of the reference without checking the reference against the RFC, and the wrong behaviour went into tests whose own comment says "past the end of source" while testing *at* the end. Those tests are rewritten; the protection that mattered (offset strictly beyond the source) is kept and parametrised.

**Termination checked before removing the guard**, since a repetition over an empty match is the obvious hazard. `*""`, `3("")`, `1*(""/"a")`, `*["a"]` and `*("") "b"` all terminate on both backends — the end-position dedup is what prevents spinning, not this guard.

Both backends changed. The rust unit test that asserted the old behaviour is updated to the new semantics, including the beyond-the-end cases.

## #261 — invalid grammars raised raw Python exceptions

```python
R.create('r = %x110000')    # was: ValueError: chr() arg not in range(0x110000)
R.create('r =/ "a"')        # was: AttributeError: no attribute '_definition'
```

Both are invalid grammars and now raise `GrammarError` naming the problem. `%x10FFFF` and `%d1114111` remain valid — the boundary is tested.

## #262 — the per-parse memo keyed on `id(self)`

An id is unique only among live objects, so a `Repetition` freed mid-parse could have its address reused and inherit the dead one's cached matches. It keys on the object now, which keeps it alive for exactly the life of the memo — one `Rule.parse` call. The type alias is updated with the reasoning rather than left to be rediscovered.

## Coverage

23 tests. Full suite green on both backends: 5,393 with rust, 1,721 pure Python, plus `cargo test`. pyright clean.

Two mistakes of my own, caught before they shipped: my binary test literal was 2²⁰ (inside the range, so it correctly did not raise), and a test used `inspect.getsource` on a class that `abnf.parser` patches with the rust implementation, so it read the wrong object under the default backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
