### PR TITLE
Bump github/codeql-action to v4.37.7 in one change

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,13 +49,13 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
       with:
         # Category disambiguates the python and rust SARIF uploads in
         # the Code Scanning UI when both finish for the same commit.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload SARIF to Code Scanning
       if: always()
-      uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
+      uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
       with:
         sarif_file: zizmor.sarif
         category: zizmor


### PR DESCRIPTION
Supersedes #224, #225 and #226.

Dependabot split one upstream release across three PRs — `upload-sarif` (#224), `analyze` (#225), `init` (#226). But `init` and `analyze` run in the **same workflow**, and CodeQL requires them to be the same version, so each PR produced a mixed v3/v4 pairing and failed on its own:

```
##[error]Loaded a configuration file for version '4.37.7', but running version '3.37.7'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.7', but running version '3.37.7'
```

That is #226 (init at v4, analyze still v3); #225 is the mirror image. Both `Analyze (python)` and `Analyze (rust)` fail on each.

All three sub-actions resolve to the same commit — `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd` — which is what confirms this is one release, not three. It has to land as one change.

`upload-sarif` in `zizmor.yml` is not part of that constraint: it is a separate workflow uploading zizmor's own SARIF, with no shared CodeQL configuration, and #224 passed CI alone. It is included here to keep all three references on one version rather than leaving a v3/v4 split across the repo.

Verified the old SHA is used by nothing else, and rewrote only lines that are `codeql-action` references rather than replacing the SHA globally.

**This cannot affect the 2.9.0 release**: `release.yml` does not use CodeQL. `codeql-analysis.yml` runs on push, PR and a weekly schedule only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
